### PR TITLE
Renamed the workspace to `bazel_contrib_rules_bazel_integration_test`.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,7 @@
+load(
+    "@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "integration_test_utils",
+)
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(
     "@cgrindel_bazel_starlib//bzlformat:defs.bzl",
@@ -7,10 +11,6 @@ load(
 load(
     "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
     "updatesrc_update_all",
-)
-load(
-    "@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
-    "integration_test_utils",
 )
 
 bzlformat_pkg(name = "bzlformat")
@@ -22,7 +22,7 @@ bzlformat_missing_pkgs(
 updatesrc_update_all(
     name = "update_all",
     targets_to_run = [
-        "@cgrindel_rules_bazel_integration_test//tools:update_deleted_packages",
+        "@bazel_contrib_rules_bazel_integration_test//tools:update_deleted_packages",
         "//doc:update",
         ":bzlformat_missing_pkgs_fix",
     ],

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bazel Integration Rules
 
-[![Build](https://github.com/cgrindel/rules_bazel_integration_test/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/cgrindel/rules_bazel_integration_test/actions/workflows/ci.yml)
+[![Build](https://github.com/bazel-contrib/rules_bazel_integration_test/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/cgrindel/rules_bazel_integration_test/actions/workflows/ci.yml)
 
 This repository contains [Bazel](https://bazel.build/) macros that execute integration tests that
 use Bazel (e.g. execute tests in a child workspace).  The macros support running integration tests
@@ -37,7 +37,7 @@ http_archive(
     sha256 = "993dea93d67895c25a093b55102ae9005bc74eb5546031b71820a79b3788c190",
     strip_prefix = "rules_bazel_integration_test-0.6.0",
     urls = [
-        "http://github.com/cgrindel/rules_bazel_integration_test/archive/0.6.0.tar.gz",
+        "http://github.com/bazel-contrib/rules_bazel_integration_test/archive/0.6.0.tar.gz",
     ],
 )
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bazel Integration Rules
 
-[![Build](https://github.com/bazel-contrib/rules_bazel_integration_test/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/cgrindel/rules_bazel_integration_test/actions/workflows/ci.yml)
+[![Build](https://github.com/bazel-contrib/rules_bazel_integration_test/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/bazel-contrib/rules_bazel_integration_test/actions/workflows/ci.yml)
 
 This repository contains [Bazel](https://bazel.build/) macros that execute integration tests that
 use Bazel (e.g. execute tests in a child workspace).  The macros support running integration tests

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add the following to your `WORKSPACE` file to add this repository and its depend
 <!-- BEGIN WORKSPACE SNIPPET -->
 ```python
 http_archive(
-    name = "cgrindel_rules_bazel_integration_test",
+    name = "bazel_contrib_rules_bazel_integration_test",
     sha256 = "993dea93d67895c25a093b55102ae9005bc74eb5546031b71820a79b3788c190",
     strip_prefix = "rules_bazel_integration_test-0.6.0",
     urls = [
@@ -41,7 +41,7 @@ http_archive(
     ],
 )
 
-load("@cgrindel_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
+load("@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 
 bazel_integration_test_rules_dependencies()
 
@@ -97,7 +97,7 @@ testing.
 
 ```python
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
-load("@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
+load("@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
 
 bazel_binaries(versions = SUPPORTED_BAZEL_VERSIONS)
 ```
@@ -117,7 +117,7 @@ Add the following to the `.bazelrc` in the parent workspace. Leave the values bl
 
 ```conf
 # To update these lines, execute 
-# `bazel run @cgrindel_rules_bazel_integration_test//tools:update_deleted_packages`
+# `bazel run @bazel_contrib_rules_bazel_integration_test//tools:update_deleted_packages`
 build --deleted_packages=
 query --deleted_packages=
 ```
@@ -128,7 +128,7 @@ Execute the following in a parent workspace directory.
 
 ```sh
 # Populate the --deleted_packages flags in the .bazelrc
-$ bazel run @cgrindel_rules_bazel_integration_test//tools:update_deleted_packages
+$ bazel run @bazel_contrib_rules_bazel_integration_test//tools:update_deleted_packages
 ```
 
 After running the utility, the `--deleted_packages` entries in the `.bazelrc` should have a
@@ -146,7 +146,7 @@ Add the following to the `BUILD.bazel` file in the `examples` directory.
 ```python
 load("//:bazel_versions.bzl", "CURRENT_BAZEL_VERSION", "OTHER_BAZEL_VERSIONS")
 load(
-    "@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "bazel_integration_test",
     "bazel_integration_tests",
     "default_test_runner",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "cgrindel_rules_bazel_integration_test")
+workspace(name = "bazel_contrib_rules_bazel_integration_test")
 
 load("//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 

--- a/bazel_integration_test/private/bazel_integration_test.bzl
+++ b/bazel_integration_test/private/bazel_integration_test.bzl
@@ -125,7 +125,7 @@ def bazel_integration_test(
     native.sh_test(
         name = name,
         srcs = [
-            "@cgrindel_rules_bazel_integration_test//bazel_integration_test/private:integration_test_wrapper.sh",
+            "@bazel_contrib_rules_bazel_integration_test//bazel_integration_test/private:integration_test_wrapper.sh",
         ],
         args = args,
         data = data,

--- a/bazel_integration_test/private/default_test_runner.bzl
+++ b/bazel_integration_test/private/default_test_runner.bzl
@@ -26,7 +26,7 @@ def default_test_runner(
     native.sh_binary(
         name = binary_name,
         srcs = [
-            "@cgrindel_rules_bazel_integration_test//bazel_integration_test/private:default_test_runner.sh",
+            "@bazel_contrib_rules_bazel_integration_test//bazel_integration_test/private:default_test_runner.sh",
         ],
         deps = [
             "@bazel_tools//tools/bash/runfiles",

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -66,7 +66,7 @@ sh_binary(
     testonly = True,
     srcs = ["use_create_scratch_dir_test.sh"],
     data = [
-        "@cgrindel_rules_bazel_integration_test//tools:create_scratch_dir",
+        "@bazel_contrib_rules_bazel_integration_test//tools:create_scratch_dir",
     ],
     deps = [
         "@bazel_tools//tools/bash/runfiles",

--- a/examples/custom_test_runner/.bazelrc
+++ b/examples/custom_test_runner/.bazelrc
@@ -1,4 +1,4 @@
 # To update these lines, execute 
-# `bazel run @cgrindel_rules_bazel_integration_test//tools:update_deleted_packages`
+# `bazel run @bazel_contrib_rules_bazel_integration_test//tools:update_deleted_packages`
 build --deleted_packages=integration_tests/workspace
 query --deleted_packages=integration_tests/workspace

--- a/examples/custom_test_runner/.bazelrc
+++ b/examples/custom_test_runner/.bazelrc
@@ -2,3 +2,6 @@
 # `bazel run @bazel_contrib_rules_bazel_integration_test//tools:update_deleted_packages`
 build --deleted_packages=integration_tests/workspace
 query --deleted_packages=integration_tests/workspace
+
+# Use the Xcode version specified by //:host_codes.
+build --xcode_version_config=//:host_xcodes

--- a/examples/custom_test_runner/BUILD.bazel
+++ b/examples/custom_test_runner/BUILD.bazel
@@ -18,3 +18,28 @@ test_suite(
     ],
     visibility = ["//:__subpackages__"],
 )
+
+# MARK: - Xcode Version
+
+# GH050: Fix compilation error when built on Xcode 13.3.
+
+xcode_version(
+    name = "version13_2_1_13C100",
+    aliases = [
+        "13.2",
+        "13.2.1",
+        "13.2.1.13C100",
+        "13C100",
+    ],
+    default_ios_sdk_version = "15.2",
+    default_macos_sdk_version = "12.1",
+    default_tvos_sdk_version = "15.2",
+    default_watchos_sdk_version = "8.3",
+    version = "13.2.1.13C100",
+)
+
+xcode_config(
+    name = "host_xcodes",
+    default = ":version13_2_1_13C100",
+    versions = [":version13_2_1_13C100"],
+)

--- a/examples/custom_test_runner/BUILD.bazel
+++ b/examples/custom_test_runner/BUILD.bazel
@@ -1,8 +1,8 @@
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(
-    "@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "integration_test_utils",
 )
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 bzl_library(
     name = "bazel_versions",

--- a/examples/custom_test_runner/WORKSPACE
+++ b/examples/custom_test_runner/WORKSPACE
@@ -3,11 +3,11 @@ workspace(name = "custom_test_runner_example")
 # MARK: - rules_bazel_integration_test
 
 local_repository(
-    name = "cgrindel_rules_bazel_integration_test",
+    name = "bazel_contrib_rules_bazel_integration_test",
     path = "../..",
 )
 
-load("@cgrindel_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
+load("@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 
 bazel_integration_test_rules_dependencies()
 
@@ -19,7 +19,7 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-load("@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
+load("@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
 
 bazel_binaries(versions = SUPPORTED_BAZEL_VERSIONS)

--- a/examples/custom_test_runner/integration_tests/BUILD.bazel
+++ b/examples/custom_test_runner/integration_tests/BUILD.bazel
@@ -1,7 +1,6 @@
 load(
-    "@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "bazel_integration_test",
-    "integration_test_utils",
 )
 load("//:bazel_versions.bzl", "CURRENT_BAZEL_VERSION")
 

--- a/examples/use_create_scratch_dir_test.sh
+++ b/examples/use_create_scratch_dir_test.sh
@@ -16,7 +16,7 @@ assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
-create_scratch_dir_sh_location=cgrindel_rules_bazel_integration_test/tools/create_scratch_dir.sh
+create_scratch_dir_sh_location=bazel_contrib_rules_bazel_integration_test/tools/create_scratch_dir.sh
 create_scratch_dir_sh="$(rlocation "${create_scratch_dir_sh_location}")" || \
   (echo >&2 "Failed to locate ${create_scratch_dir_sh_location}" && exit 1)
 

--- a/release/workspace_snippet.tmpl
+++ b/release/workspace_snippet.tmpl
@@ -1,6 +1,6 @@
 ${http_archive_statement}
 
-load("@cgrindel_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
+load("@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 
 bazel_integration_test_rules_dependencies()
 

--- a/tests/tools_tests/create_scratch_dir_test.sh
+++ b/tests/tools_tests/create_scratch_dir_test.sh
@@ -14,7 +14,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 assertions_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/assertions.sh)"
 source "${assertions_lib}"
 
-create_scratch_dir_sh_location=cgrindel_rules_bazel_integration_test/tools/create_scratch_dir.sh
+create_scratch_dir_sh_location=bazel_contrib_rules_bazel_integration_test/tools/create_scratch_dir.sh
 create_scratch_dir_sh="$(rlocation "${create_scratch_dir_sh_location}")" || \
   (echo >&2 "Failed to locate ${create_scratch_dir_sh_location}" && exit 1)
 

--- a/tests/tools_tests/find_child_workspace_packages_test.sh
+++ b/tests/tools_tests/find_child_workspace_packages_test.sh
@@ -14,12 +14,12 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 assertions_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/assertions.sh)"
 source "${assertions_lib}"
 
-find_bin="$(rlocation cgrindel_rules_bazel_integration_test/tools/find_child_workspace_packages.sh)"
+find_bin="$(rlocation bazel_contrib_rules_bazel_integration_test/tools/find_child_workspace_packages.sh)"
 
 starting_path="${PWD}"
 
 # Set up the parent workspace
-setup_test_workspace_sh_location=cgrindel_rules_bazel_integration_test/tests/tools_tests/setup_test_workspace.sh
+setup_test_workspace_sh_location=bazel_contrib_rules_bazel_integration_test/tests/tools_tests/setup_test_workspace.sh
 setup_test_workspace_sh="$(rlocation "${setup_test_workspace_sh_location}")" || \
   (echo >&2 "Failed to locate ${setup_test_workspace_sh_location}" && exit 1)
 source "${setup_test_workspace_sh}"

--- a/tests/tools_tests/update_deleted_packages_test.sh
+++ b/tests/tools_tests/update_deleted_packages_test.sh
@@ -14,12 +14,12 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 assertions_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/assertions.sh)"
 source "${assertions_lib}"
 
-update_bin="$(rlocation cgrindel_rules_bazel_integration_test/tools/update_deleted_packages.sh)"
+update_bin="$(rlocation bazel_contrib_rules_bazel_integration_test/tools/update_deleted_packages.sh)"
 
 starting_path="${PWD}"
 
 # Set up the parent workspace
-setup_test_workspace_sh_location=cgrindel_rules_bazel_integration_test/tests/tools_tests/setup_test_workspace.sh
+setup_test_workspace_sh_location=bazel_contrib_rules_bazel_integration_test/tests/tools_tests/setup_test_workspace.sh
 setup_test_workspace_sh="$(rlocation "${setup_test_workspace_sh_location}")" || \
   (echo >&2 "Failed to locate ${setup_test_workspace_sh_location}" && exit 1)
 source "${setup_test_workspace_sh}"

--- a/tools/update_deleted_packages.sh
+++ b/tools/update_deleted_packages.sh
@@ -26,7 +26,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-find_pkgs_script="$(rlocation cgrindel_rules_bazel_integration_test/tools/find_child_workspace_packages.sh)"
+find_pkgs_script="$(rlocation bazel_contrib_rules_bazel_integration_test/tools/find_child_workspace_packages.sh)"
 
 messages_sh_location=cgrindel_bazel_starlib/shlib/lib/messages.sh
 messages_sh="$(rlocation "${messages_sh_location}")" || \


### PR DESCRIPTION
Related to #47.