### PR TITLE
Removed `bazel_` prefix from the workspace name.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,3 @@
-load(
-    "@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
-    "integration_test_utils",
-)
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(
     "@cgrindel_bazel_starlib//bzlformat:defs.bzl",
@@ -11,6 +7,10 @@ load(
 load(
     "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
     "updatesrc_update_all",
+)
+load(
+    "@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "integration_test_utils",
 )
 
 bzlformat_pkg(name = "bzlformat")
@@ -22,7 +22,7 @@ bzlformat_missing_pkgs(
 updatesrc_update_all(
     name = "update_all",
     targets_to_run = [
-        "@bazel_contrib_rules_bazel_integration_test//tools:update_deleted_packages",
+        "@contrib_rules_bazel_integration_test//tools:update_deleted_packages",
         "//doc:update",
         ":bzlformat_missing_pkgs_fix",
     ],

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add the following to your `WORKSPACE` file to add this repository and its depend
 <!-- BEGIN WORKSPACE SNIPPET -->
 ```python
 http_archive(
-    name = "bazel_contrib_rules_bazel_integration_test",
+    name = "contrib_rules_bazel_integration_test",
     sha256 = "993dea93d67895c25a093b55102ae9005bc74eb5546031b71820a79b3788c190",
     strip_prefix = "rules_bazel_integration_test-0.6.0",
     urls = [
@@ -41,7 +41,7 @@ http_archive(
     ],
 )
 
-load("@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
+load("@contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 
 bazel_integration_test_rules_dependencies()
 
@@ -97,7 +97,7 @@ testing.
 
 ```python
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
-load("@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
+load("@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
 
 bazel_binaries(versions = SUPPORTED_BAZEL_VERSIONS)
 ```
@@ -117,7 +117,7 @@ Add the following to the `.bazelrc` in the parent workspace. Leave the values bl
 
 ```conf
 # To update these lines, execute 
-# `bazel run @bazel_contrib_rules_bazel_integration_test//tools:update_deleted_packages`
+# `bazel run @contrib_rules_bazel_integration_test//tools:update_deleted_packages`
 build --deleted_packages=
 query --deleted_packages=
 ```
@@ -128,7 +128,7 @@ Execute the following in a parent workspace directory.
 
 ```sh
 # Populate the --deleted_packages flags in the .bazelrc
-$ bazel run @bazel_contrib_rules_bazel_integration_test//tools:update_deleted_packages
+$ bazel run @contrib_rules_bazel_integration_test//tools:update_deleted_packages
 ```
 
 After running the utility, the `--deleted_packages` entries in the `.bazelrc` should have a
@@ -146,7 +146,7 @@ Add the following to the `BUILD.bazel` file in the `examples` directory.
 ```python
 load("//:bazel_versions.bzl", "CURRENT_BAZEL_VERSION", "OTHER_BAZEL_VERSIONS")
 load(
-    "@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "bazel_integration_test",
     "bazel_integration_tests",
     "default_test_runner",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "bazel_contrib_rules_bazel_integration_test")
+workspace(name = "contrib_rules_bazel_integration_test")
 
 load("//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 

--- a/bazel_integration_test/private/bazel_integration_test.bzl
+++ b/bazel_integration_test/private/bazel_integration_test.bzl
@@ -125,7 +125,7 @@ def bazel_integration_test(
     native.sh_test(
         name = name,
         srcs = [
-            "@bazel_contrib_rules_bazel_integration_test//bazel_integration_test/private:integration_test_wrapper.sh",
+            "@contrib_rules_bazel_integration_test//bazel_integration_test/private:integration_test_wrapper.sh",
         ],
         args = args,
         data = data,

--- a/bazel_integration_test/private/default_test_runner.bzl
+++ b/bazel_integration_test/private/default_test_runner.bzl
@@ -26,7 +26,7 @@ def default_test_runner(
     native.sh_binary(
         name = binary_name,
         srcs = [
-            "@bazel_contrib_rules_bazel_integration_test//bazel_integration_test/private:default_test_runner.sh",
+            "@contrib_rules_bazel_integration_test//bazel_integration_test/private:default_test_runner.sh",
         ],
         deps = [
             "@bazel_tools//tools/bash/runfiles",

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -66,7 +66,7 @@ sh_binary(
     testonly = True,
     srcs = ["use_create_scratch_dir_test.sh"],
     data = [
-        "@bazel_contrib_rules_bazel_integration_test//tools:create_scratch_dir",
+        "@contrib_rules_bazel_integration_test//tools:create_scratch_dir",
     ],
     deps = [
         "@bazel_tools//tools/bash/runfiles",

--- a/examples/custom_test_runner/.bazelrc
+++ b/examples/custom_test_runner/.bazelrc
@@ -1,5 +1,5 @@
 # To update these lines, execute 
-# `bazel run @bazel_contrib_rules_bazel_integration_test//tools:update_deleted_packages`
+# `bazel run @contrib_rules_bazel_integration_test//tools:update_deleted_packages`
 build --deleted_packages=integration_tests/workspace
 query --deleted_packages=integration_tests/workspace
 

--- a/examples/custom_test_runner/BUILD.bazel
+++ b/examples/custom_test_runner/BUILD.bazel
@@ -1,8 +1,8 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(
-    "@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "integration_test_utils",
 )
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 bzl_library(
     name = "bazel_versions",

--- a/examples/custom_test_runner/WORKSPACE
+++ b/examples/custom_test_runner/WORKSPACE
@@ -3,11 +3,11 @@ workspace(name = "custom_test_runner_example")
 # MARK: - rules_bazel_integration_test
 
 local_repository(
-    name = "bazel_contrib_rules_bazel_integration_test",
+    name = "contrib_rules_bazel_integration_test",
     path = "../..",
 )
 
-load("@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
+load("@contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 
 bazel_integration_test_rules_dependencies()
 
@@ -19,7 +19,7 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-load("@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
+load("@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
 
 bazel_binaries(versions = SUPPORTED_BAZEL_VERSIONS)

--- a/examples/custom_test_runner/integration_tests/BUILD.bazel
+++ b/examples/custom_test_runner/integration_tests/BUILD.bazel
@@ -1,5 +1,5 @@
 load(
-    "@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "bazel_integration_test",
 )
 load("//:bazel_versions.bzl", "CURRENT_BAZEL_VERSION")

--- a/examples/use_create_scratch_dir_test.sh
+++ b/examples/use_create_scratch_dir_test.sh
@@ -16,7 +16,7 @@ assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
-create_scratch_dir_sh_location=bazel_contrib_rules_bazel_integration_test/tools/create_scratch_dir.sh
+create_scratch_dir_sh_location=contrib_rules_bazel_integration_test/tools/create_scratch_dir.sh
 create_scratch_dir_sh="$(rlocation "${create_scratch_dir_sh_location}")" || \
   (echo >&2 "Failed to locate ${create_scratch_dir_sh_location}" && exit 1)
 

--- a/release/workspace_snippet.tmpl
+++ b/release/workspace_snippet.tmpl
@@ -1,6 +1,6 @@
 ${http_archive_statement}
 
-load("@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
+load("@contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 
 bazel_integration_test_rules_dependencies()
 

--- a/tests/tools_tests/create_scratch_dir_test.sh
+++ b/tests/tools_tests/create_scratch_dir_test.sh
@@ -14,7 +14,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 assertions_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/assertions.sh)"
 source "${assertions_lib}"
 
-create_scratch_dir_sh_location=bazel_contrib_rules_bazel_integration_test/tools/create_scratch_dir.sh
+create_scratch_dir_sh_location=contrib_rules_bazel_integration_test/tools/create_scratch_dir.sh
 create_scratch_dir_sh="$(rlocation "${create_scratch_dir_sh_location}")" || \
   (echo >&2 "Failed to locate ${create_scratch_dir_sh_location}" && exit 1)
 

--- a/tests/tools_tests/find_child_workspace_packages_test.sh
+++ b/tests/tools_tests/find_child_workspace_packages_test.sh
@@ -14,12 +14,12 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 assertions_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/assertions.sh)"
 source "${assertions_lib}"
 
-find_bin="$(rlocation bazel_contrib_rules_bazel_integration_test/tools/find_child_workspace_packages.sh)"
+find_bin="$(rlocation contrib_rules_bazel_integration_test/tools/find_child_workspace_packages.sh)"
 
 starting_path="${PWD}"
 
 # Set up the parent workspace
-setup_test_workspace_sh_location=bazel_contrib_rules_bazel_integration_test/tests/tools_tests/setup_test_workspace.sh
+setup_test_workspace_sh_location=contrib_rules_bazel_integration_test/tests/tools_tests/setup_test_workspace.sh
 setup_test_workspace_sh="$(rlocation "${setup_test_workspace_sh_location}")" || \
   (echo >&2 "Failed to locate ${setup_test_workspace_sh_location}" && exit 1)
 source "${setup_test_workspace_sh}"

--- a/tests/tools_tests/update_deleted_packages_test.sh
+++ b/tests/tools_tests/update_deleted_packages_test.sh
@@ -14,12 +14,12 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 assertions_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/assertions.sh)"
 source "${assertions_lib}"
 
-update_bin="$(rlocation bazel_contrib_rules_bazel_integration_test/tools/update_deleted_packages.sh)"
+update_bin="$(rlocation contrib_rules_bazel_integration_test/tools/update_deleted_packages.sh)"
 
 starting_path="${PWD}"
 
 # Set up the parent workspace
-setup_test_workspace_sh_location=bazel_contrib_rules_bazel_integration_test/tests/tools_tests/setup_test_workspace.sh
+setup_test_workspace_sh_location=contrib_rules_bazel_integration_test/tests/tools_tests/setup_test_workspace.sh
 setup_test_workspace_sh="$(rlocation "${setup_test_workspace_sh_location}")" || \
   (echo >&2 "Failed to locate ${setup_test_workspace_sh_location}" && exit 1)
 source "${setup_test_workspace_sh}"

--- a/tools/update_deleted_packages.sh
+++ b/tools/update_deleted_packages.sh
@@ -26,7 +26,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-find_pkgs_script="$(rlocation bazel_contrib_rules_bazel_integration_test/tools/find_child_workspace_packages.sh)"
+find_pkgs_script="$(rlocation contrib_rules_bazel_integration_test/tools/find_child_workspace_packages.sh)"
 
 messages_sh_location=cgrindel_bazel_starlib/shlib/lib/messages.sh
 messages_sh="$(rlocation "${messages_sh_location}")" || \


### PR DESCRIPTION
Related to #47.