### PR TITLE
Add custom workspace name to generated workspace snippet.

### DIFF
--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -14,6 +14,7 @@ bzlformat_pkg(name = "bzlformat")
 generate_workspace_snippet(
     name = "generate_workspace_snippet",
     template = "workspace_snippet.tmpl",
+    workspace_name = "contrib_rules_bazel_integration_test",
 )
 
 generate_release_notes(


### PR DESCRIPTION
We switch to a custom workspace name, `contrib_rules_bazel_integration_test`, in #51. This specifies the custom name for workspace snippet generation.