### PR TITLE
Allow specification of data for test_runner in bazel_integration_test

### DIFF
--- a/bazel_integration_test/private/bazel_integration_test.bzl
+++ b/bazel_integration_test/private/bazel_integration_test.bzl
@@ -119,6 +119,7 @@ def bazel_integration_test(
 
         args.extend(["--workspace", "$(location :%s)" % (bazel_wksp_file_name)])
         data.extend([workspace_files_name, bazel_wksp_file_name])
+        data.extend(kwargs.pop("data", []))
 
     env_inherit = env_inherit + additional_env_inherit
 


### PR DESCRIPTION
This PR adds ability to use `data` attribute to provide files needed by test_runner unrelated to test workspace