### PR TITLE
Add env parameter to bazel_integration_test, remove "CC" passing

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,8 +3,8 @@
 # This lets us glob() up all the files inside the examples to make them inputs to tests
 # (Note, we cannot use `common --deleted_packages` because the bazel version command doesn't support it)
 # To update these lines, run tools/update_deleted_packages.sh
-build --deleted_packages=examples/custom_test_runner,examples/custom_test_runner/Sources/CustomTestRunner,examples/custom_test_runner/Tests/CustomTestRunnerTests,examples/custom_test_runner/integration_tests,examples/custom_test_runner/integration_tests/workspace,examples/simple,examples/simple/mockascript,examples/simple/mockascript/private,examples/simple/tests,tests/params_tests/workspace
-query --deleted_packages=examples/custom_test_runner,examples/custom_test_runner/Sources/CustomTestRunner,examples/custom_test_runner/Tests/CustomTestRunnerTests,examples/custom_test_runner/integration_tests,examples/custom_test_runner/integration_tests/workspace,examples/simple,examples/simple/mockascript,examples/simple/mockascript/private,examples/simple/tests,tests/params_tests/workspace
+build --deleted_packages=examples/custom_test_runner,examples/custom_test_runner/integration_tests,examples/custom_test_runner/integration_tests/workspace,examples/custom_test_runner/Sources/CustomTestRunner,examples/custom_test_runner/Tests/CustomTestRunnerTests,examples/simple,examples/simple/mockascript,examples/simple/mockascript/private,examples/simple/tests,tests/params_tests/workspace
+query --deleted_packages=examples/custom_test_runner,examples/custom_test_runner/integration_tests,examples/custom_test_runner/integration_tests/workspace,examples/custom_test_runner/Sources/CustomTestRunner,examples/custom_test_runner/Tests/CustomTestRunnerTests,examples/simple,examples/simple/mockascript,examples/simple/mockascript/private,examples/simple/tests,tests/params_tests/workspace
 
 # Import Shared settings
 import %workspace%/shared.bazelrc

--- a/bazel_integration_test/private/bazel_integration_test.bzl
+++ b/bazel_integration_test/private/bazel_integration_test.bzl
@@ -12,7 +12,8 @@ load(":integration_test_utils.bzl", "integration_test_utils")
 # By default, inherit the following environment variables
 #   HOME: Avoid "could not get the user's cache directory: $HOME is not defined"
 #   SUDO_ASKPASS: Support executing tests that require sudo for certain steps.
-_DEFAULT_ENV_INHERIT = ["SUDO_ASKPASS", "HOME"]
+#   CC: if Bazel use specific C-compiler it should be inherited by default
+_DEFAULT_ENV_INHERIT = ["SUDO_ASKPASS", "HOME", "CC"]
 
 def bazel_integration_test(
         name,

--- a/bazel_integration_test/private/bazel_integration_test.bzl
+++ b/bazel_integration_test/private/bazel_integration_test.bzl
@@ -23,6 +23,7 @@ def bazel_integration_test(
         workspace_files = None,
         tags = integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS,
         timeout = "long",
+        env = {},
         env_inherit = _DEFAULT_ENV_INHERIT,
         additional_env_inherit = [],
         **kwargs):
@@ -57,6 +58,8 @@ def bazel_integration_test(
         tags: The Bazel tags to apply to the test declaration.
         timeout: A valid Bazel timeout value.
                  https://docs.bazel.build/versions/main/test-encyclopedia.html#role-of-the-test-runner
+        env: Optional. A dictionary of `strings`. Specifies additional environment
+                variables to be passed to the test.
         env_inherit: Optional. Override the env_inherit values passed to the
                      test. Only do this if you understand what needs to be
                      passed along. Most folks will want to use
@@ -134,11 +137,7 @@ def bazel_integration_test(
             "@cgrindel_bazel_starlib//shlib/lib:messages",
         ],
         timeout = timeout,
-        env = select({
-            # Linux platforms require that CC be set to clang.
-            "@platforms//os:linux": {"CC": "clang"},
-            "//conditions:default": {},
-        }),
+        env = env,
         env_inherit = env_inherit,
         tags = tags,
         **kwargs

--- a/bazel_integration_test/py/bazel_py_integration_tests.bzl
+++ b/bazel_integration_test/py/bazel_py_integration_tests.bzl
@@ -3,7 +3,7 @@
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//bazel_integration_test:defs.bzl", "bazel_integration_tests")
 
-def bazel_py_integration_tests(name, srcs, bazel_versions, main = None, deps = [], env={}):
+def bazel_py_integration_tests(name, srcs, bazel_versions, main = None, deps = [], env = {}):
     # Declare the test runner
     runner_name = name
     py_binary(

--- a/bazel_integration_test/py/bazel_py_integration_tests.bzl
+++ b/bazel_integration_test/py/bazel_py_integration_tests.bzl
@@ -3,7 +3,7 @@
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//bazel_integration_test:defs.bzl", "bazel_integration_tests")
 
-def bazel_py_integration_tests(name, srcs, bazel_versions, main = None, deps = []):
+def bazel_py_integration_tests(name, srcs, bazel_versions, main = None, deps = [], env={}):
     # Declare the test runner
     runner_name = name
     py_binary(
@@ -21,4 +21,5 @@ def bazel_py_integration_tests(name, srcs, bazel_versions, main = None, deps = [
         name = name,
         bazel_versions = bazel_versions,
         test_runner = runner_name,
+        env = env,
     )

--- a/doc/rules_and_macros_overview.md
+++ b/doc/rules_and_macros_overview.md
@@ -47,7 +47,7 @@ default test runner is provided by the `default_test_runner` macro.
 | <a id="bazel_integration_test-tags"></a>tags |  The Bazel tags to apply to the test declaration.   |  <code>["exclusive", "manual"]</code> |
 | <a id="bazel_integration_test-timeout"></a>timeout |  A valid Bazel timeout value. https://docs.bazel.build/versions/main/test-encyclopedia.html#role-of-the-test-runner   |  <code>"long"</code> |
 | <a id="bazel_integration_test-env"></a>env |  Optional. A dictionary of <code>strings</code>. Specifies additional environment variables to be passed to the test.   |  <code>{}</code> |
-| <a id="bazel_integration_test-env_inherit"></a>env_inherit |  Optional. Override the env_inherit values passed to the test. Only do this if you understand what needs to be passed along. Most folks will want to use <code>additional_env_inherit</code> to pass additional env_inherit values.   |  <code>["SUDO_ASKPASS", "HOME"]</code> |
+| <a id="bazel_integration_test-env_inherit"></a>env_inherit |  Optional. Override the env_inherit values passed to the test. Only do this if you understand what needs to be passed along. Most folks will want to use <code>additional_env_inherit</code> to pass additional env_inherit values.   |  <code>["SUDO_ASKPASS", "HOME", "CC"]</code> |
 | <a id="bazel_integration_test-additional_env_inherit"></a>additional_env_inherit |  Optional. Specify additional <code>env_inherit</code> values that should be passed to the test.   |  <code>[]</code> |
 | <a id="bazel_integration_test-kwargs"></a>kwargs |  additional attributes like timeout and visibility   |  none |
 
@@ -75,7 +75,7 @@ Macro that defines a set Bazel integration tests each executed with a different 
 | <a id="bazel_integration_tests-workspace_files"></a>workspace_files |  Optional. A <code>list</code> of files for the child workspace. If not specified, then it is derived from the <code>workspace_path</code>.   |  <code>None</code> |
 | <a id="bazel_integration_tests-tags"></a>tags |  The Bazel tags to apply to the test declaration.   |  <code>["exclusive", "manual"]</code> |
 | <a id="bazel_integration_tests-timeout"></a>timeout |  A valid Bazel timeout value. https://docs.bazel.build/versions/main/test-encyclopedia.html#role-of-the-test-runner   |  <code>"long"</code> |
-| <a id="bazel_integration_tests-env_inherit"></a>env_inherit |  Optional. Override the env_inherit values passed to the test. Only do this if you understand what needs to be passed along. Most folks will want to use <code>additional_env_inherit</code> to pass additional env_inherit values.   |  <code>["SUDO_ASKPASS", "HOME"]</code> |
+| <a id="bazel_integration_tests-env_inherit"></a>env_inherit |  Optional. Override the env_inherit values passed to the test. Only do this if you understand what needs to be passed along. Most folks will want to use <code>additional_env_inherit</code> to pass additional env_inherit values.   |  <code>["SUDO_ASKPASS", "HOME", "CC"]</code> |
 | <a id="bazel_integration_tests-additional_env_inherit"></a>additional_env_inherit |  Optional. Specify additional <code>env_inherit</code> values that should be passed to the test.   |  <code>[]</code> |
 | <a id="bazel_integration_tests-kwargs"></a>kwargs |  additional attributes like timeout and visibility   |  none |
 

--- a/doc/rules_and_macros_overview.md
+++ b/doc/rules_and_macros_overview.md
@@ -17,7 +17,8 @@ On this page:
 
 <pre>
 bazel_integration_test(<a href="#bazel_integration_test-name">name</a>, <a href="#bazel_integration_test-test_runner">test_runner</a>, <a href="#bazel_integration_test-bazel_version">bazel_version</a>, <a href="#bazel_integration_test-bazel_binary">bazel_binary</a>, <a href="#bazel_integration_test-workspace_path">workspace_path</a>,
-                       <a href="#bazel_integration_test-workspace_files">workspace_files</a>, <a href="#bazel_integration_test-tags">tags</a>, <a href="#bazel_integration_test-timeout">timeout</a>, <a href="#bazel_integration_test-env_inherit">env_inherit</a>, <a href="#bazel_integration_test-additional_env_inherit">additional_env_inherit</a>, <a href="#bazel_integration_test-kwargs">kwargs</a>)
+                       <a href="#bazel_integration_test-workspace_files">workspace_files</a>, <a href="#bazel_integration_test-tags">tags</a>, <a href="#bazel_integration_test-timeout">timeout</a>, <a href="#bazel_integration_test-env">env</a>, <a href="#bazel_integration_test-env_inherit">env_inherit</a>, <a href="#bazel_integration_test-additional_env_inherit">additional_env_inherit</a>,
+                       <a href="#bazel_integration_test-kwargs">kwargs</a>)
 </pre>
 
 Macro that defines a set of targets for a single Bazel integration test.
@@ -45,6 +46,7 @@ default test runner is provided by the `default_test_runner` macro.
 | <a id="bazel_integration_test-workspace_files"></a>workspace_files |  Optional. A <code>list</code> of files for the child workspace. If not specified, then it is derived from the <code>workspace_path</code>.   |  <code>None</code> |
 | <a id="bazel_integration_test-tags"></a>tags |  The Bazel tags to apply to the test declaration.   |  <code>["exclusive", "manual"]</code> |
 | <a id="bazel_integration_test-timeout"></a>timeout |  A valid Bazel timeout value. https://docs.bazel.build/versions/main/test-encyclopedia.html#role-of-the-test-runner   |  <code>"long"</code> |
+| <a id="bazel_integration_test-env"></a>env |  Optional. A dictionary of <code>strings</code>. Specifies additional environment variables to be passed to the test.   |  <code>{}</code> |
 | <a id="bazel_integration_test-env_inherit"></a>env_inherit |  Optional. Override the env_inherit values passed to the test. Only do this if you understand what needs to be passed along. Most folks will want to use <code>additional_env_inherit</code> to pass additional env_inherit values.   |  <code>["SUDO_ASKPASS", "HOME"]</code> |
 | <a id="bazel_integration_test-additional_env_inherit"></a>additional_env_inherit |  Optional. Specify additional <code>env_inherit</code> values that should be passed to the test.   |  <code>[]</code> |
 | <a id="bazel_integration_test-kwargs"></a>kwargs |  additional attributes like timeout and visibility   |  none |

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -21,11 +21,6 @@ default_test_runner(
 bazel_integration_test(
     name = "simple_test",
     bazel_version = CURRENT_BAZEL_VERSION,
-    env = select({
-        # Linux platforms require that CC be set to clang.
-        "@platforms//os:linux": {"CC": "clang"},
-        "//conditions:default": {},
-    }),
     test_runner = ":simple_test_runner",
     workspace_path = "simple",
 )
@@ -37,11 +32,6 @@ bazel_integration_tests(
     # buildifier: disable=duplicated-name
     name = "simple_test",
     bazel_versions = OTHER_BAZEL_VERSIONS,
-    env = select({
-        # Linux platforms require that CC be set to clang.
-        "@platforms//os:linux": {"CC": "clang"},
-        "//conditions:default": {},
-    }),
     test_runner = ":simple_test_runner",
     workspace_path = "simple",
 )
@@ -62,11 +52,6 @@ default_test_runner(
 bazel_integration_test(
     name = "custom_test_runner_test",
     bazel_version = CURRENT_BAZEL_VERSION,
-    env = select({
-        # Linux platforms require that CC be set to clang.
-        "@platforms//os:linux": {"CC": "clang"},
-        "//conditions:default": {},
-    }),
     test_runner = ":custom_test_runner_test_runner",
     workspace_files = integration_test_utils.glob_workspace_files("custom_test_runner") + [
         "//:local_repository_files",
@@ -92,11 +77,6 @@ sh_binary(
 bazel_integration_test(
     name = "use_create_scratch_dir_test",
     bazel_version = CURRENT_BAZEL_VERSION,
-    env = select({
-        # Linux platforms require that CC be set to clang.
-        "@platforms//os:linux": {"CC": "clang"},
-        "//conditions:default": {},
-    }),
     test_runner = ":use_create_scratch_dir_test_runner",
     workspace_files = integration_test_utils.glob_workspace_files("simple") + [
         "//:local_repository_files",
@@ -119,11 +99,6 @@ sh_binary(
 bazel_integration_test(
     name = "dynamic_workspace_test",
     bazel_version = CURRENT_BAZEL_VERSION,
-    env = select({
-        # Linux platforms require that CC be set to clang.
-        "@platforms//os:linux": {"CC": "clang"},
-        "//conditions:default": {},
-    }),
     test_runner = ":dynamic_workspace_test_runner",
 )
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -22,6 +22,11 @@ bazel_integration_test(
     name = "simple_test",
     bazel_version = CURRENT_BAZEL_VERSION,
     test_runner = ":simple_test_runner",
+    env = select({
+    # Linux platforms require that CC be set to clang.
+        "@platforms//os:linux": {"CC": "clang"},
+        "//conditions:default": {},
+    }),
     workspace_path = "simple",
 )
 
@@ -33,6 +38,11 @@ bazel_integration_tests(
     name = "simple_test",
     bazel_versions = OTHER_BAZEL_VERSIONS,
     test_runner = ":simple_test_runner",
+    env = select({
+    # Linux platforms require that CC be set to clang.
+        "@platforms//os:linux": {"CC": "clang"},
+        "//conditions:default": {},
+    }),
     workspace_path = "simple",
 )
 
@@ -53,6 +63,11 @@ bazel_integration_test(
     name = "custom_test_runner_test",
     bazel_version = CURRENT_BAZEL_VERSION,
     test_runner = ":custom_test_runner_test_runner",
+    env = select({
+        # Linux platforms require that CC be set to clang.
+        "@platforms//os:linux": {"CC": "clang"},
+        "//conditions:default": {},
+    }),
     workspace_files = integration_test_utils.glob_workspace_files("custom_test_runner") + [
         "//:local_repository_files",
     ],
@@ -78,6 +93,11 @@ bazel_integration_test(
     name = "use_create_scratch_dir_test",
     bazel_version = CURRENT_BAZEL_VERSION,
     test_runner = ":use_create_scratch_dir_test_runner",
+    env = select({
+    # Linux platforms require that CC be set to clang.
+        "@platforms//os:linux": {"CC": "clang"},
+        "//conditions:default": {},
+    }),
     workspace_files = integration_test_utils.glob_workspace_files("simple") + [
         "//:local_repository_files",
     ],
@@ -100,6 +120,11 @@ bazel_integration_test(
     name = "dynamic_workspace_test",
     bazel_version = CURRENT_BAZEL_VERSION,
     test_runner = ":dynamic_workspace_test_runner",
+    env = select({
+    # Linux platforms require that CC be set to clang.
+        "@platforms//os:linux": {"CC": "clang"},
+        "//conditions:default": {},
+    }),
 )
 
 # MARK: - Test Suite

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -21,12 +21,12 @@ default_test_runner(
 bazel_integration_test(
     name = "simple_test",
     bazel_version = CURRENT_BAZEL_VERSION,
-    test_runner = ":simple_test_runner",
     env = select({
-    # Linux platforms require that CC be set to clang.
+        # Linux platforms require that CC be set to clang.
         "@platforms//os:linux": {"CC": "clang"},
         "//conditions:default": {},
     }),
+    test_runner = ":simple_test_runner",
     workspace_path = "simple",
 )
 
@@ -37,12 +37,12 @@ bazel_integration_tests(
     # buildifier: disable=duplicated-name
     name = "simple_test",
     bazel_versions = OTHER_BAZEL_VERSIONS,
-    test_runner = ":simple_test_runner",
     env = select({
-    # Linux platforms require that CC be set to clang.
+        # Linux platforms require that CC be set to clang.
         "@platforms//os:linux": {"CC": "clang"},
         "//conditions:default": {},
     }),
+    test_runner = ":simple_test_runner",
     workspace_path = "simple",
 )
 
@@ -62,12 +62,12 @@ default_test_runner(
 bazel_integration_test(
     name = "custom_test_runner_test",
     bazel_version = CURRENT_BAZEL_VERSION,
-    test_runner = ":custom_test_runner_test_runner",
     env = select({
         # Linux platforms require that CC be set to clang.
         "@platforms//os:linux": {"CC": "clang"},
         "//conditions:default": {},
     }),
+    test_runner = ":custom_test_runner_test_runner",
     workspace_files = integration_test_utils.glob_workspace_files("custom_test_runner") + [
         "//:local_repository_files",
     ],
@@ -92,12 +92,12 @@ sh_binary(
 bazel_integration_test(
     name = "use_create_scratch_dir_test",
     bazel_version = CURRENT_BAZEL_VERSION,
-    test_runner = ":use_create_scratch_dir_test_runner",
     env = select({
-    # Linux platforms require that CC be set to clang.
+        # Linux platforms require that CC be set to clang.
         "@platforms//os:linux": {"CC": "clang"},
         "//conditions:default": {},
     }),
+    test_runner = ":use_create_scratch_dir_test_runner",
     workspace_files = integration_test_utils.glob_workspace_files("simple") + [
         "//:local_repository_files",
     ],
@@ -119,12 +119,12 @@ sh_binary(
 bazel_integration_test(
     name = "dynamic_workspace_test",
     bazel_version = CURRENT_BAZEL_VERSION,
-    test_runner = ":dynamic_workspace_test_runner",
     env = select({
-    # Linux platforms require that CC be set to clang.
+        # Linux platforms require that CC be set to clang.
         "@platforms//os:linux": {"CC": "clang"},
         "//conditions:default": {},
     }),
+    test_runner = ":dynamic_workspace_test_runner",
 )
 
 # MARK: - Test Suite

--- a/tests/params_tests/BUILD.bazel
+++ b/tests/params_tests/BUILD.bazel
@@ -19,11 +19,6 @@ default_test_runner(
 bazel_integration_test(
     name = "default_env_inherit_int_test",
     bazel_version = CURRENT_BAZEL_VERSION,
-    env = select({
-        # Linux platforms require that CC be set to clang.
-        "@platforms//os:linux": {"CC": "clang"},
-        "//conditions:default": {},
-    }),
     test_runner = ":test_runner",
     workspace_path = "workspace",
 )
@@ -42,14 +37,10 @@ env_inherit_attr_test(
 bazel_integration_test(
     name = "override_env_inherit_int_test",
     bazel_version = CURRENT_BAZEL_VERSION,
-    env = select({
-        # Linux platforms require that CC be set to clang.
-        "@platforms//os:linux": {"CC": "clang"},
-        "//conditions:default": {},
-    }),
     env_inherit = [
         "HOME",
         "SUDO_ASKPASS",
+        "CC",
         "CHICKEN",
     ],
     test_runner = ":test_runner",
@@ -74,11 +65,6 @@ bazel_integration_test(
         "CHICKEN",
     ],
     bazel_version = CURRENT_BAZEL_VERSION,
-    env = select({
-        # Linux platforms require that CC be set to clang.
-        "@platforms//os:linux": {"CC": "clang"},
-        "//conditions:default": {},
-    }),
     test_runner = ":test_runner",
     workspace_path = "workspace",
 )

--- a/tests/params_tests/BUILD.bazel
+++ b/tests/params_tests/BUILD.bazel
@@ -20,7 +20,7 @@ bazel_integration_test(
     name = "default_env_inherit_int_test",
     bazel_version = CURRENT_BAZEL_VERSION,
     env = select({
-    # Linux platforms require that CC be set to clang.
+        # Linux platforms require that CC be set to clang.
         "@platforms//os:linux": {"CC": "clang"},
         "//conditions:default": {},
     }),
@@ -43,7 +43,7 @@ bazel_integration_test(
     name = "override_env_inherit_int_test",
     bazel_version = CURRENT_BAZEL_VERSION,
     env = select({
-    # Linux platforms require that CC be set to clang.
+        # Linux platforms require that CC be set to clang.
         "@platforms//os:linux": {"CC": "clang"},
         "//conditions:default": {},
     }),
@@ -70,15 +70,15 @@ env_inherit_attr_test(
 
 bazel_integration_test(
     name = "additional_env_inherit_int_test",
-    env = select({
-    # Linux platforms require that CC be set to clang.
-        "@platforms//os:linux": {"CC": "clang"},
-        "//conditions:default": {},
-    }),
     additional_env_inherit = [
         "CHICKEN",
     ],
     bazel_version = CURRENT_BAZEL_VERSION,
+    env = select({
+        # Linux platforms require that CC be set to clang.
+        "@platforms//os:linux": {"CC": "clang"},
+        "//conditions:default": {},
+    }),
     test_runner = ":test_runner",
     workspace_path = "workspace",
 )

--- a/tests/params_tests/BUILD.bazel
+++ b/tests/params_tests/BUILD.bazel
@@ -19,6 +19,11 @@ default_test_runner(
 bazel_integration_test(
     name = "default_env_inherit_int_test",
     bazel_version = CURRENT_BAZEL_VERSION,
+    env = select({
+    # Linux platforms require that CC be set to clang.
+        "@platforms//os:linux": {"CC": "clang"},
+        "//conditions:default": {},
+    }),
     test_runner = ":test_runner",
     workspace_path = "workspace",
 )
@@ -37,6 +42,11 @@ env_inherit_attr_test(
 bazel_integration_test(
     name = "override_env_inherit_int_test",
     bazel_version = CURRENT_BAZEL_VERSION,
+    env = select({
+    # Linux platforms require that CC be set to clang.
+        "@platforms//os:linux": {"CC": "clang"},
+        "//conditions:default": {},
+    }),
     env_inherit = [
         "HOME",
         "SUDO_ASKPASS",
@@ -60,6 +70,11 @@ env_inherit_attr_test(
 
 bazel_integration_test(
     name = "additional_env_inherit_int_test",
+    env = select({
+    # Linux platforms require that CC be set to clang.
+        "@platforms//os:linux": {"CC": "clang"},
+        "//conditions:default": {},
+    }),
     additional_env_inherit = [
         "CHICKEN",
     ],


### PR DESCRIPTION
Following the discussion in #70 this PR adds `env` parameter to `bazel_integration_test` and removes passing `CC=clang` by default 