### PR TITLE
fix: address issues running `find_child_workspace_packages.sh` with empty child workspaces

### DIFF
--- a/tests/tools_tests/find_child_workspace_packages_test.sh
+++ b/tests/tools_tests/find_child_workspace_packages_test.sh
@@ -43,7 +43,10 @@ source "${setup_test_workspace_sh}"
 expected=("examples/child_a" "examples/child_a/foo" "somewhere_else/child_b/bar")
 
 # Execute specifying workspace flag
-actual=( $(. "${find_bin}" --workspace "${parent_dir}") )
+actual=()
+while IFS=$'\n' read -r line; do actual+=("$line"); done < <(
+  "${find_bin}" --workspace "${parent_dir}"
+)
 assert_equal "${#expected[@]}" "${#actual[@]}"
 for (( i = 0; i < ${#expected[@]}; i++ )); do
   assert_equal "${expected[i]}" "${actual[i]}"
@@ -51,8 +54,12 @@ done
 
 
 # Execute inside the parent workspace; find the parent workspace root
+# shellcheck disable=SC2154
 cd "${examples_dir}"
-actual=( $(. "${find_bin}") )
+actual=()
+while IFS=$'\n' read -r line; do actual+=("$line"); done < <(
+  "${find_bin}"
+)
 assert_equal "${#expected[@]}" "${#actual[@]}"
 for (( i = 0; i < ${#expected[@]}; i++ )); do
   assert_equal "${expected[i]}" "${actual[i]}"

--- a/tests/tools_tests/find_child_workspace_packages_test.sh
+++ b/tests/tools_tests/find_child_workspace_packages_test.sh
@@ -16,14 +16,29 @@ source "${assertions_lib}"
 
 find_bin="$(rlocation contrib_rules_bazel_integration_test/tools/find_child_workspace_packages.sh)"
 
-starting_path="${PWD}"
+# MARK - Execute without a workspace
+
+"${find_bin}" --workspace "${PWD}" \
+  || fail "Expected no failure with no child workspace."
+
+# MARK - Execute with empty workspace
+
+empty_example_workspace_dir="${PWD}/examples/empty"
+mkdir -p "${empty_example_workspace_dir}"
+touch "${empty_example_workspace_dir}/WORKSPACE"
+
+"${find_bin}" --workspace "${PWD}" \
+  || fail "Expected no failure with empty child workspace."
+
+rm -rf "${empty_example_workspace_dir}"
+
+# MARK - Execute with a workspace
 
 # Set up the parent workspace
 setup_test_workspace_sh_location=contrib_rules_bazel_integration_test/tests/tools_tests/setup_test_workspace.sh
 setup_test_workspace_sh="$(rlocation "${setup_test_workspace_sh_location}")" || \
   (echo >&2 "Failed to locate ${setup_test_workspace_sh_location}" && exit 1)
 source "${setup_test_workspace_sh}"
-
 
 expected=("examples/child_a" "examples/child_a/foo" "somewhere_else/child_b/bar")
 

--- a/tests/tools_tests/update_deleted_packages_test.sh
+++ b/tests/tools_tests/update_deleted_packages_test.sh
@@ -18,10 +18,12 @@ update_bin="$(rlocation contrib_rules_bazel_integration_test/tools/update_delete
 
 starting_path="${PWD}"
 
+
 # Set up the parent workspace
 setup_test_workspace_sh_location=contrib_rules_bazel_integration_test/tests/tools_tests/setup_test_workspace.sh
 setup_test_workspace_sh="$(rlocation "${setup_test_workspace_sh_location}")" || \
   (echo >&2 "Failed to locate ${setup_test_workspace_sh_location}" && exit 1)
+# shellcheck source=SCRIPTDIR/setup_test_workspace.sh
 source "${setup_test_workspace_sh}"
 
 # MARK - Variables
@@ -40,7 +42,7 @@ reset_test_workspace() {
 # MARK - Test Specifying Flags
 
 # Execute specifying workspace flag
-. "${update_bin}" --workspace "${parent_dir}" --bazelrc "${parent_bazelrc}"
+"${update_bin}" --workspace "${parent_dir}" --bazelrc "${parent_bazelrc}"
 
 actual=$(< "${parent_bazelrc}")
 assert_equal "${expected_with_change}" "${actual}"
@@ -58,7 +60,7 @@ reset_test_workspace
 
 # Execute inside the parent workspace; find the parent workspace root
 cd "${examples_dir}"
-. "${update_bin}" 
+"${update_bin}" 
 
 actual=$(< "${parent_bazelrc}")
 assert_equal "${expected_with_change}" "${actual}"
@@ -83,7 +85,7 @@ cd "${fake_bazel_output_dir}"
 export BUILD_WORKING_DIRECTORY="${examples_dir}"
 
 # Execute the update
-. "${update_bin}" 
+"${update_bin}" 
 
 actual=$(< "${parent_bazelrc}")
 assert_equal "${expected_with_change}" "${actual}"

--- a/tools/find_child_workspace_packages.sh
+++ b/tools/find_child_workspace_packages.sh
@@ -63,6 +63,8 @@ done
 [[ -d "${workspace_root:-}" ]] || exit_on_error "The workspace root was not found. ${workspace_root:-}"
 
 all_workspace_dirs=( $(find_workspace_dirs "${workspace_root}") )
+[[ ${#all_workspace_dirs[@]} -gt 0 ]] || exit 0
+
 child_workspace_dirs=()
 for workspace_dir in "${all_workspace_dirs[@]}" ; do
   [[ "${workspace_dir}" != "${workspace_root}" ]] && \
@@ -73,6 +75,9 @@ absolute_path_pkgs=()
 for child_workspace_dir in "${child_workspace_dirs[@]}" ; do
   absolute_path_pkgs+=( $(find_bazel_pkgs "${child_workspace_dir}") )
 done
+
+# If no packages, then exit gracefully
+[[ ${#absolute_path_pkgs[@]} -gt 0 ]] || exit 0
 absolute_path_pkgs=( $(sort_items "${absolute_path_pkgs[@]}") )
 
 # Strip the workspace_root prefix from the paths

--- a/tools/find_child_workspace_packages.sh
+++ b/tools/find_child_workspace_packages.sh
@@ -58,11 +58,14 @@ while (("$#")); do
   esac
 done
 
-[[ -z "${workspace_root:-}" ]] && [[ ! -z "${BUILD_WORKING_DIRECTORY:-}"  ]] && workspace_root="${BUILD_WORKING_DIRECTORY:-}"
+[[ -z "${workspace_root:-}" ]] && [[ -n "${BUILD_WORKING_DIRECTORY:-}"  ]] && workspace_root="${BUILD_WORKING_DIRECTORY:-}"
 [[ -z "${workspace_root:-}" ]] && workspace_root="$(dirname "$(upsearch WORKSPACE)")"
 [[ -d "${workspace_root:-}" ]] || exit_on_error "The workspace root was not found. ${workspace_root:-}"
 
-all_workspace_dirs=( $(find_workspace_dirs "${workspace_root}") )
+# all_workspace_dirs=( $(find_workspace_dirs "${workspace_root}") )
+all_workspace_dirs=()
+while IFS=$'\n' read -r line; do all_workspace_dirs+=("$line"); done \
+  < <(find_workspace_dirs "${workspace_root}")
 [[ ${#all_workspace_dirs[@]} -gt 0 ]] || exit 0
 
 child_workspace_dirs=()
@@ -73,14 +76,19 @@ done
 
 absolute_path_pkgs=()
 for child_workspace_dir in "${child_workspace_dirs[@]}" ; do
-  absolute_path_pkgs+=( $(find_bazel_pkgs "${child_workspace_dir}") )
+  while IFS=$'\n' read -r line; do absolute_path_pkgs+=("$line"); done < <(
+    find_bazel_pkgs "${child_workspace_dir}"
+  )
 done
 
 # If no packages, then exit gracefully
 [[ ${#absolute_path_pkgs[@]} -gt 0 ]] || exit 0
-absolute_path_pkgs=( $(sort_items "${absolute_path_pkgs[@]}") )
+sorted_abs_path_pkgs=()
+while IFS=$'\n' read -r line; do sorted_abs_path_pkgs+=("$line"); done < <(
+  sort_items "${absolute_path_pkgs[@]}"
+)
 
 # Strip the workspace_root prefix from the paths
-pkgs=( "${absolute_path_pkgs[@]#"${workspace_root}/"}")
+pkgs=( "${sorted_abs_path_pkgs[@]#"${workspace_root}/"}")
 
 print_by_line "${pkgs[@]}"

--- a/tools/update_deleted_packages.sh
+++ b/tools/update_deleted_packages.sh
@@ -90,6 +90,9 @@ fi
 # Find the child packages
 pkgs=( $(. "${find_pkgs_script}" --workspace "${workspace_root}") )
 
+# If no pkgs, then exit gracefully
+[[ ${#pkgs[@]} -gt 0 ]] || exit 0
+
 
 # Update the .bazelrc file with the deleted packages flag.
 # The sed -i.bak pattern is compatible between macos and linux


### PR DESCRIPTION
- Address Bash errors when executing `find_child_workspace_packages.sh` and `update_deleted_packages.sh` with empty child workspaces.
- Address ShellCheck warnings.