### PR TITLE
fix: apply suggestions from GH081 code review and address ShellCheck warnings

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,8 +3,8 @@
 # This lets us glob() up all the files inside the examples to make them inputs to tests
 # (Note, we cannot use `common --deleted_packages` because the bazel version command doesn't support it)
 # To update these lines, run tools/update_deleted_packages.sh
-build --deleted_packages=examples/custom_test_runner,examples/custom_test_runner/integration_tests,examples/custom_test_runner/integration_tests/workspace,examples/custom_test_runner/Sources/CustomTestRunner,examples/custom_test_runner/Tests/CustomTestRunnerTests,examples/simple,examples/simple/mockascript,examples/simple/mockascript/private,examples/simple/tests,tests/params_tests/workspace
-query --deleted_packages=examples/custom_test_runner,examples/custom_test_runner/integration_tests,examples/custom_test_runner/integration_tests/workspace,examples/custom_test_runner/Sources/CustomTestRunner,examples/custom_test_runner/Tests/CustomTestRunnerTests,examples/simple,examples/simple/mockascript,examples/simple/mockascript/private,examples/simple/tests,tests/params_tests/workspace
+build --deleted_packages=examples/custom_test_runner,examples/custom_test_runner/Sources/CustomTestRunner,examples/custom_test_runner/Tests/CustomTestRunnerTests,examples/custom_test_runner/integration_tests,examples/custom_test_runner/integration_tests/workspace,examples/simple,examples/simple/mockascript,examples/simple/mockascript/private,examples/simple/tests,tests/params_tests/workspace
+query --deleted_packages=examples/custom_test_runner,examples/custom_test_runner/Sources/CustomTestRunner,examples/custom_test_runner/Tests/CustomTestRunnerTests,examples/custom_test_runner/integration_tests,examples/custom_test_runner/integration_tests/workspace,examples/simple,examples/simple/mockascript,examples/simple/mockascript/private,examples/simple/tests,tests/params_tests/workspace
 
 # Import Shared settings
 import %workspace%/shared.bazelrc


### PR DESCRIPTION
Related to #81.

- The `deleted_packages` list for this repo changed because the packages are being sorted. It looks like the sort was not working previously or the list was generated before the sort was added to `find_child_workspace_packages.sh`.