### PR TITLE
chore: additional cleanup for find_child_workspace_packages

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -8,6 +8,11 @@ filegroup(
     visibility = ["//:__subpackages__"],
 )
 
+sh_library(
+    name = "shared_fns",
+    srcs = ["shared_fns.sh"],
+)
+
 # MARK: - Binary Declarations
 
 sh_binary(
@@ -15,8 +20,10 @@ sh_binary(
     srcs = ["find_child_workspace_packages.sh"],
     visibility = ["//visibility:public"],
     deps = [
+        ":shared_fns",
         "@bazel_tools//tools/bash/runfiles",
         "@cgrindel_bazel_starlib//shlib/lib:arrays",
+        "@cgrindel_bazel_starlib//shlib/lib:fail",
         "@cgrindel_bazel_starlib//shlib/lib:files",
     ],
 )

--- a/tools/shared_fns.sh
+++ b/tools/shared_fns.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+find_workspace_dirs() {
+  local path="${1}"
+  # Make sure that the -print0 is the last primary for find. Otherwise, you
+  # will get undesirable results.
+  find "${path}" -name "WORKSPACE" -print0  | xargs -0 -n 1 dirname
+}


### PR DESCRIPTION
- Moved `find_workspace_dirs` to a `shared_fns.sh` file. This will be used by a new tool in an upcoming PR.
- Addressed ShellCheck warning suggesting the use of `-print0` with `find`.
- Refactored boolean shortcuts to `if` statements.
- Replaced use of `exit_on_error` with `fail`. The `exit_on_error` function no longer exists.

Related to #82.