### PR TITLE
feat: add `remove_child_wksp_bazel_symlinks` to remove child workspace symlinks

### DIFF
--- a/tests/tools_tests/BUILD.bazel
+++ b/tests/tools_tests/BUILD.bazel
@@ -47,3 +47,16 @@ sh_test(
         "@cgrindel_bazel_starlib//shlib/lib:assertions",
     ],
 )
+
+sh_test(
+    name = "remove_child_wksp_bazel_symlinks_test",
+    srcs = ["remove_child_wksp_bazel_symlinks_test.sh"],
+    data = [
+        "//tools:remove_child_wksp_bazel_symlinks",
+    ],
+    deps = [
+        ":setup_test_workspace",
+        "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_starlib//shlib/lib:assertions",
+    ],
+)

--- a/tests/tools_tests/remove_child_wksp_bazel_symlinks_test.sh
+++ b/tests/tools_tests/remove_child_wksp_bazel_symlinks_test.sh
@@ -54,7 +54,15 @@ ln -s "${bazel_out}" "${rogue_symlink}"
 # Remove 
 "${remove_child_wksp_bazel_symlinks_sh}" --workspace "${parent_dir}"
 
-[[ -e "${parent_symlink}" ]] || fail "Expected parent symlink to exist. ${parent_symlink}"
-[[ ! -e "${child_a_symlink}" ]] || fail "Expected child_a symlink not to exist. ${child_a_symlink}"
-[[ ! -e "${child_b_symlink}" ]] || fail "Expected child_b symlink not to exist. ${child_b_symlink}"
-[[ -e "${rogue_symlink}" ]] || fail "Expected rogue symlink to exist. ${rogue_symlink}"
+if [[ ! -e "${parent_symlink}" ]]; then
+  fail "Expected parent symlink to exist. ${parent_symlink}"
+fi
+if [[ -e "${child_a_symlink}" ]]; then
+  fail "Expected child_a symlink not to exist. ${child_a_symlink}"
+fi
+if [[ -e "${child_b_symlink}" ]]; then
+  fail "Expected child_b symlink not to exist. ${child_b_symlink}"
+fi
+if [[ ! -e "${rogue_symlink}" ]]; then
+  fail "Expected rogue symlink to exist. ${rogue_symlink}"
+fi

--- a/tests/tools_tests/remove_child_wksp_bazel_symlinks_test.sh
+++ b/tests/tools_tests/remove_child_wksp_bazel_symlinks_test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -o nounset -o pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -o errexit
+# --- end runfiles.bash initialization v2 ---
+
+# MARK - Locate Deps
+
+assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
+assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+source "${assertions_sh}"
+
+remove_child_wksp_bazel_symlinks_sh_location=contrib_rules_bazel_integration_test/tools/remove_child_wksp_bazel_symlinks.sh
+remove_child_wksp_bazel_symlinks_sh="$(rlocation "${remove_child_wksp_bazel_symlinks_sh_location}")" || \
+  (echo >&2 "Failed to locate ${remove_child_wksp_bazel_symlinks_sh_location}" && exit 1)
+
+# Set up the parent workspace
+setup_test_workspace_sh_location=contrib_rules_bazel_integration_test/tests/tools_tests/setup_test_workspace.sh
+setup_test_workspace_sh="$(rlocation "${setup_test_workspace_sh_location}")" || \
+  (echo >&2 "Failed to locate ${setup_test_workspace_sh_location}" && exit 1)
+# shellcheck source=SCRIPTDIR/setup_test_workspace.sh
+source "${setup_test_workspace_sh}"
+
+# MARK - Test
+
+bazel_out="${PWD}/bazel_out"
+parent_bazel_out="${bazel_out}/parent"
+child_a_bazel_out="${bazel_out}/child_a"
+child_b_bazel_out="${bazel_out}/child_b"
+mkdir -p "${bazel_out}" "${child_a_bazel_out}" "${child_b_bazel_out}" "${parent_bazel_out}"
+
+# Add bazel symlinks
+parent_symlink="${parent_dir}/bazel-parent"
+child_a_symlink="${child_a_dir}/bazel-child_a"
+child_b_symlink="${child_b_dir}/bazel-child_b"
+ln -s "${parent_bazel_out}" "${parent_symlink}"
+ln -s "${child_a_bazel_out}" "${child_a_symlink}"
+ln -s "${child_b_bazel_out}" "${child_b_symlink}"
+
+# Add a rogue symlink; looks like a bazel- symlink but is not in a workspace
+# directory.
+rogue_symlink="${examples_dir}/bazel-rogue"
+ln -s "${bazel_out}" "${rogue_symlink}"
+
+# Remove 
+"${remove_child_wksp_bazel_symlinks_sh}" --workspace "${parent_dir}"
+
+[[ -e "${parent_symlink}" ]] || fail "Expected parent symlink to exist. ${parent_symlink}"
+[[ ! -e "${child_a_symlink}" ]] || fail "Expected child_a symlink not to exist. ${child_a_symlink}"
+[[ ! -e "${child_b_symlink}" ]] || fail "Expected child_b symlink not to exist. ${child_b_symlink}"
+[[ -e "${rogue_symlink}" ]] || fail "Expected rogue symlink to exist. ${rogue_symlink}"

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -8,6 +8,11 @@ filegroup(
     visibility = ["//:__subpackages__"],
 )
 
+sh_library(
+    name = "shared_fns",
+    srcs = ["shared_fns.sh"],
+)
+
 # MARK: - Binary Declarations
 
 sh_binary(
@@ -15,8 +20,10 @@ sh_binary(
     srcs = ["find_child_workspace_packages.sh"],
     visibility = ["//visibility:public"],
     deps = [
+        ":shared_fns",
         "@bazel_tools//tools/bash/runfiles",
         "@cgrindel_bazel_starlib//shlib/lib:arrays",
+        "@cgrindel_bazel_starlib//shlib/lib:fail",
         "@cgrindel_bazel_starlib//shlib/lib:files",
     ],
 )

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -54,3 +54,15 @@ sh_binary(
         "@cgrindel_bazel_starlib//shlib/lib:paths",
     ],
 )
+
+sh_binary(
+    name = "remove_child_wksp_bazel_symlinks",
+    srcs = ["remove_child_wksp_bazel_symlinks.sh"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":shared_fns",
+        "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_starlib//shlib/lib:fail",
+        "@cgrindel_bazel_starlib//shlib/lib:files",
+    ],
+)

--- a/tools/remove_child_wksp_bazel_symlinks.sh
+++ b/tools/remove_child_wksp_bazel_symlinks.sh
@@ -33,7 +33,9 @@ source "${shared_fns_sh}"
 
 remove_bazel_symlinks() {
   local workspace_dir="${1}"
-  find "${workspace_dir}" -maxdepth 1 -type l -name "bazel-*" -print0 | xargs -0 rm
+  # The -r for xargs is important for GNU xargs. Without it, xargs will run the utility
+  # at least once. In this case, we do not want the rm command to run if empty.
+  find "${workspace_dir}" -maxdepth 1 -type l -name "bazel-*" -print0 | xargs -0 -r rm
 }
 
 # MARK - Process Args

--- a/tools/remove_child_wksp_bazel_symlinks.sh
+++ b/tools/remove_child_wksp_bazel_symlinks.sh
@@ -49,10 +49,11 @@ while (("$#")); do
   esac
 done
 
+
 if [[ -z "${workspace_root:-}" ]] && [[ -n "${BUILD_WORKING_DIRECTORY:-}" ]]; then
   workspace_root="${BUILD_WORKING_DIRECTORY:-}" 
 fi
-if [[ -n "${workspace_root:-}" ]]; then
+if [[ -z "${workspace_root:-}" ]]; then
   workspace_root="$(dirname "$(upsearch WORKSPACE)")"
 fi
 if [[ ! -d "${workspace_root:-}" ]]; then

--- a/tools/remove_child_wksp_bazel_symlinks.sh
+++ b/tools/remove_child_wksp_bazel_symlinks.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -o nounset -o pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -o errexit
+# --- end runfiles.bash initialization v2 ---
+
+# MARK - Locate Deps
+
+fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
+fail_sh="$(rlocation "${fail_sh_location}")" || \
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+source "${fail_sh}"
+
+files_sh_location=cgrindel_bazel_starlib/shlib/lib/files.sh
+files_sh="$(rlocation "${files_sh_location}")" || \
+  (echo >&2 "Failed to locate ${files_sh_location}" && exit 1)
+source "${files_sh}"
+
+shared_fns_sh_location=contrib_rules_bazel_integration_test/tools/shared_fns.sh
+shared_fns_sh="$(rlocation "${shared_fns_sh_location}")" || \
+  (echo >&2 "Failed to locate ${shared_fns_sh_location}" && exit 1)
+# shellcheck source=SCRIPTDIR/shared_fns.sh
+source "${shared_fns_sh}"
+
+# MARK - Functions
+
+remove_bazel_symlinks() {
+  local workspace_dir="${1}"
+  find "${workspace_dir}" -maxdepth 1 -type l -name "bazel-*" -print0 | xargs -0 rm
+}
+
+# MARK - Process Args
+
+while (("$#")); do
+  case "${1}" in
+    "--workspace")
+      workspace_root="${2}"
+      shift 2
+      ;;
+    *)
+      shift 1 ;;
+  esac
+done
+
+if [[ -z "${workspace_root:-}" ]] && [[ -n "${BUILD_WORKING_DIRECTORY:-}" ]]; then
+  workspace_root="${BUILD_WORKING_DIRECTORY:-}" 
+fi
+if [[ -n "${workspace_root:-}" ]]; then
+  workspace_root="$(dirname "$(upsearch WORKSPACE)")"
+fi
+if [[ ! -d "${workspace_root:-}" ]]; then
+  fail "The workspace root was not found. ${workspace_root:-}"
+fi
+
+workspace_dirs=()
+while IFS=$'\n' read -r line; do workspace_dirs+=("$line"); done < <(
+  find_workspace_dirs "${workspace_root}"
+)
+
+if [[ ${#workspace_dirs[@]} -eq 0 ]]; then
+  warn "No workspace directories were found." 
+  exit 0
+fi
+
+for workspace_dir in "${workspace_dirs[@]}" ; do
+  if [[ "${workspace_dir}" == "${workspace_root}" ]]; then
+    continue
+  fi
+  remove_bazel_symlinks "${workspace_dir}"
+done

--- a/tools/shared_fns.sh
+++ b/tools/shared_fns.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+find_workspace_dirs() {
+  local path="${1}"
+  # Make sure that the -print0 is the last primary for find. Otherwise, you
+  # will get undesirable results.
+  find "${path}" -name "WORKSPACE" -print0  | xargs -0 -n 1 dirname
+}


### PR DESCRIPTION
## Problem

If a Bazel workspace has child workspaces and Bazel builds are run in the child workspaces, Bazel will create symlinks in the child workspace directories. This can lead to infinite symlink expansion errors in the parent workspace.

## Solution

Delete the Bazel symlinks in the child workspaces. This avoids the infinite symlink expansion and preserves the Bazel build outputs for the child workspaces.

## Usage

Run `@contrib_rules_bazel_integration_test//tools:remove_child_wksp_bazel_symlinks` from the parent workspace. It looks for the Bazel symlinks in the child workspace while keeping the Bazel symlinks in the parent workspace.
