### PR TITLE
Windows support

### DIFF
--- a/bazel_integration_test/private/bazel_integration_test.bzl
+++ b/bazel_integration_test/private/bazel_integration_test.bzl
@@ -102,7 +102,10 @@ def bazel_integration_test(
     select_file(
         name = bazel_bin_name,
         srcs = bazel_binary,
-        subpath = "bazel",
+        subpath = select({
+            "@platforms//os:windows": "bazel.exe",
+            "//conditions:default": "bazel",
+        }),
     )
 
     args = [


### PR DESCRIPTION
Trying to fix the CI failure here, in the rules_rust tests: https://buildkite.com/bazel/rules-rust-rustlang/builds/7703#01855631-4f26-4779-bb7c-5e96463f074e

```
(00:46:14) ERROR: C:/b/bk-windows-6dj8/bazel/rules-rust-rustlang/test/integration/clippy/BUILD.bazel:3:34: in select_file rule //test/integration/clippy:test_bazel_binary:
Traceback (most recent call last):
	File "C:/b/7h7n2dmc/external/bazel_skylib/rules/select_file.bzl", line 36, column 13, in _impl
		fail("Can not find specified file in [%s]" % files_str)
Error in fail: Can not find specified file in [external/build_bazel_bazel_6_0_0/bazel.exe]
```

Refs https://github.com/bazelbuild/rules_rust/pull/1731.

Fixes #69.