### PR TITLE
Support trailing lines in .bazelversion

### DIFF
--- a/bazel_integration_test/private/bazel_binaries.bzl
+++ b/bazel_integration_test/private/bazel_binaries.bzl
@@ -65,17 +65,26 @@ def _get_installer(repository_ctx, version):
     repository_ctx.download_and_extract(**args)
 
 def get_version_from_file(repository_ctx):
+    """Read the Bazel version string from the version file.
+
+    Args:
+      repository_ctx: Repository rule context object.
+
+    Returns:
+      The first non-empty line of the file with surrounding white space stripped.
+    """
     version_file = repository_ctx.attr.version_file
     if repository_ctx.attr.version_file == None:
         return None
     version_file_path = repository_ctx.path(version_file)
 
     # Strip spaces and newlines
-    return (repository_ctx
-        .read(version_file_path)
-        .lstrip(" \n")  # strip leading white space
-        .partition("\n")[0]  # read the first nonempty line
-        .rstrip(" \n")  # strip trailing white space
+    return (
+        repository_ctx
+            .read(version_file_path)
+            .lstrip(" \n")  # strip leading white space
+            .partition("\n")[0]  # read the first nonempty line
+            .rstrip(" \n")  # strip trailing white space
     )
 
 def _bazel_binary_impl(repository_ctx):

--- a/bazel_integration_test/private/bazel_binaries.bzl
+++ b/bazel_integration_test/private/bazel_binaries.bzl
@@ -71,7 +71,12 @@ def get_version_from_file(repository_ctx):
     version_file_path = repository_ctx.path(version_file)
 
     # Strip spaces and newlines
-    return repository_ctx.read(version_file_path).strip(" \n")
+    return (repository_ctx
+        .read(version_file_path)
+        .lstrip(" \n")  # strip leading white space
+        .partition("\n")[0]  # read the first nonempty line
+        .rstrip(" \n")  # strip trailing white space
+    )
 
 def _bazel_binary_impl(repository_ctx):
     version = repository_ctx.attr.version

--- a/bazel_integration_test/private/bazel_binaries.bzl
+++ b/bazel_integration_test/private/bazel_binaries.bzl
@@ -64,7 +64,7 @@ def _get_installer(repository_ctx, version):
 
     repository_ctx.download_and_extract(**args)
 
-def _get_version_from_file(repository_ctx):
+def get_version_from_file(repository_ctx):
     version_file = repository_ctx.attr.version_file
     if repository_ctx.attr.version_file == None:
         return None
@@ -76,7 +76,7 @@ def _get_version_from_file(repository_ctx):
 def _bazel_binary_impl(repository_ctx):
     version = repository_ctx.attr.version
     if version == "":
-        version = _get_version_from_file(repository_ctx)
+        version = get_version_from_file(repository_ctx)
     if version == None:
         fail("A `version` or `version_file` must be specified.")
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,6 +1,9 @@
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+load(":integration_test_impl_tests.bzl", "integration_test_impl_test_suite")
 load(":integration_test_utils_tests.bzl", "integration_test_utils_test_suite")
 
 bzlformat_pkg(name = "bzlformat")
+
+integration_test_impl_test_suite()
 
 integration_test_utils_test_suite()

--- a/tests/integration_test_impl_tests.bzl
+++ b/tests/integration_test_impl_tests.bzl
@@ -1,0 +1,53 @@
+"""Tests for private implementation functions."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+# buildifier: disable=bzl-visibility
+load("//bazel_integration_test/private:bazel_binaries.bzl", "get_version_from_file")
+
+def _parse_bazelversion_file_test(ctx):
+    env = unittest.begin(ctx)
+
+    def mock_repository_ctx(*, version_file, version_path, version_content):
+        def path(_):
+            return version_path
+
+        def read(_):
+            return version_content
+
+        return struct(
+            attr = struct(version_file = version_file),
+            path = path,
+            read = read,
+        )
+
+    simple_ctx = mock_repository_ctx(
+        version_file = "//:.bazelversion",
+        version_path = "/workspace/.bazelversion",
+        version_content = "6.0.0",
+    )
+    asserts.equals(env, "6.0.0", get_version_from_file(simple_ctx), "Parses file containing only the version.")
+
+    whitespace_ctx = mock_repository_ctx(
+        version_file = "//:.bazelversion",
+        version_path = "/workspace/.bazelversion",
+        version_content = " \n6.0.0\n \n",
+    )
+    asserts.equals(env, "6.0.0", get_version_from_file(whitespace_ctx), "Parses file with surrounding whitespace.")
+
+    trailing_lines_ctx = mock_repository_ctx(
+        version_file = "//:.bazelversion",
+        version_path = "/workspace/.bazelversion",
+        version_content = "6.0.0\na trailing line\n# and another line\n",
+    )
+    asserts.equals(env, "6.0.0", get_version_from_file(trailing_lines_ctx), "Parses file with trainling lines.")
+
+    return unittest.end(env)
+
+parse_bazelversion_file_test = unittest.make(_parse_bazelversion_file_test)
+
+def integration_test_impl_test_suite():
+    return unittest.suite(
+        "integration_test_impl_tests",
+        parse_bazelversion_file_test,
+    )


### PR DESCRIPTION
Closes #108

Handles trailing lines in the .bazelversion parser.
Adds unit tests for the parsing function.
I was debating whether to add an integration test for this. However, it seemed much easier to mock the `repository_ctx` object and write a unit test. But, that required exposing the function (dropping the `_` prefix). It's still part of a `private` module, so not part of the public API. But, let me know if you'd prefer some other route.
