### PR TITLE
chore: build a release source archive

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: cgrindel/gha_configure_git_user@v1
 
     # Create the release
-    - uses: cgrindel/gha_create_release@v1
+    - uses: cgrindel/gha_create_release@v2
       with:
         release_tag: ${{  github.event.inputs.release_tag }}
         reset_tag: ${{  github.event.inputs.reset_tag }}

--- a/bazel_integration_test/deps.bzl
+++ b/bazel_integration_test/deps.bzl
@@ -17,10 +17,9 @@ def bazel_integration_test_rules_dependencies():
     maybe(
         http_archive,
         name = "cgrindel_bazel_starlib",
-        sha256 = "3f04ca2e3bef99563c6d96728b0a09f8484bc3c61ca804d29f67e86e6043c038",
-        strip_prefix = "bazel-starlib-0.11.0",
+        sha256 = "2c21a982f4928dafed4a4229ec25c656c56fdb98d17fb7e79928b60f828fbdd7",
         urls = [
-            "http://github.com/cgrindel/bazel-starlib/archive/v0.11.0.tar.gz",
+            "https://github.com/cgrindel/bazel-starlib/releases/download/v0.12.1/bazel-starlib.v0.12.1.tar.gz",
         ],
     )
 

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -1,9 +1,12 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
     "@cgrindel_bazel_starlib//bzlrelease:defs.bzl",
     "create_release",
     "generate_release_notes",
     "generate_workspace_snippet",
+    "hash_sha256",
+    "release_archive",
     "update_readme",
 )
 
@@ -30,4 +33,24 @@ update_readme(
 create_release(
     name = "create",
     workflow_name = "Create Release",
+)
+
+release_archive(
+    name = "archive",
+    srcs = ["//:local_repository_files"],
+    out = "rules_bazel_integration_test.tar.gz",
+)
+
+hash_sha256(
+    name = "archive_sha256",
+    src = ":archive",
+    out = "rules_bazel_integration_test.tar.gz.sha256",
+)
+
+build_test(
+    name = "archive_build_test",
+    targets = [
+        ":archive",
+        ":archive_sha256",
+    ],
 )


### PR DESCRIPTION
- Upgrade `bazel-starlib` to 0.12.1.
- Upgrade `gha_create_release` to v2.
- Build a release source archive from the files used to execute the child workspaces. This provides the minimum set of files needed to use the `rules_bazel_integration_test` repository.

Closes #111.