### PR TITLE
chore: change the default name for the repository

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,7 +10,7 @@ load(
     "updatesrc_update_all",
 )
 load(
-    "@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "integration_test_utils",
 )
 
@@ -25,8 +25,8 @@ tidy(
     targets = [
         # Remove the child workspace symlinks before doing some of the other
         # operations that my experience infinite symlink expansion errors.
-        "@contrib_rules_bazel_integration_test//tools:remove_child_wksp_bazel_symlinks",
-        "@contrib_rules_bazel_integration_test//tools:update_deleted_packages",
+        "@rules_bazel_integration_test//tools:remove_child_wksp_bazel_symlinks",
+        "@rules_bazel_integration_test//tools:update_deleted_packages",
         ":bzlformat_missing_pkgs_fix",
         ":update_all",
     ],
@@ -35,7 +35,7 @@ tidy(
 updatesrc_update_all(
     name = "update_all",
     targets_to_run = [
-        "@contrib_rules_bazel_integration_test//tools:update_deleted_packages",
+        "@rules_bazel_integration_test//tools:update_deleted_packages",
         "//doc:update",
         ":bzlformat_missing_pkgs_fix",
     ],

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ Add the following to your `WORKSPACE` file to add this repository and its depend
 <!-- BEGIN WORKSPACE SNIPPET -->
 ```python
 http_archive(
-    name = "contrib_rules_bazel_integration_test",
+    name = "rules_bazel_integration_test",
     sha256 = "6da8278ae7c78df6c7c222102c05e5807a3e5e65297f2a75968c899f7937750a",
     urls = [
         "https://github.com/bazel-contrib/rules_bazel_integration_test/releases/download/v0.10.3/rules_bazel_integration_test.v0.10.3.tar.gz",
     ],
 )
 
-load("@contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
+load("@rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 
 bazel_integration_test_rules_dependencies()
 
@@ -102,7 +102,7 @@ testing.
 
 ```python
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
-load("@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
+load("@rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
 
 bazel_binaries(versions = SUPPORTED_BAZEL_VERSIONS)
 ```
@@ -122,7 +122,7 @@ Add the following to the `.bazelrc` in the parent workspace. Leave the values bl
 
 ```conf
 # To update these lines, execute 
-# `bazel run @contrib_rules_bazel_integration_test//tools:update_deleted_packages`
+# `bazel run @rules_bazel_integration_test//tools:update_deleted_packages`
 build --deleted_packages=
 query --deleted_packages=
 ```
@@ -133,7 +133,7 @@ Execute the following in a parent workspace directory.
 
 ```sh
 # Populate the --deleted_packages flags in the .bazelrc
-$ bazel run @contrib_rules_bazel_integration_test//tools:update_deleted_packages
+$ bazel run @rules_bazel_integration_test//tools:update_deleted_packages
 ```
 
 After running the utility, the `--deleted_packages` entries in the `.bazelrc` should have a
@@ -151,7 +151,7 @@ Add the following to the `BUILD.bazel` file in the `examples` directory.
 ```python
 load("//:bazel_versions.bzl", "CURRENT_BAZEL_VERSION", "OTHER_BAZEL_VERSIONS")
 load(
-    "@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "bazel_integration_test",
     "bazel_integration_tests",
     "default_test_runner",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "contrib_rules_bazel_integration_test")
+workspace(name = "rules_bazel_integration_test")
 
 load("//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 

--- a/bazel_integration_test/private/bazel_integration_test.bzl
+++ b/bazel_integration_test/private/bazel_integration_test.bzl
@@ -153,7 +153,7 @@ def bazel_integration_test(
     native.sh_test(
         name = name,
         srcs = [
-            "@contrib_rules_bazel_integration_test//bazel_integration_test/private:integration_test_wrapper.sh",
+            "@rules_bazel_integration_test//bazel_integration_test/private:integration_test_wrapper.sh",
         ],
         args = args,
         data = data,

--- a/bazel_integration_test/private/default_test_runner.bzl
+++ b/bazel_integration_test/private/default_test_runner.bzl
@@ -26,7 +26,7 @@ def default_test_runner(
     native.sh_binary(
         name = binary_name,
         srcs = [
-            "@contrib_rules_bazel_integration_test//bazel_integration_test/private:default_test_runner.sh",
+            "@rules_bazel_integration_test//bazel_integration_test/private:default_test_runner.sh",
         ],
         deps = [
             "@bazel_tools//tools/bash/runfiles",

--- a/doc/custom_test_runners.md
+++ b/doc/custom_test_runners.md
@@ -39,7 +39,7 @@ actual source files. Modifications to these files will change the actual sources
 A utility, called [`create_scratch_dir.sh`](/tools/create_scratch_dir.sh), provides a convenient way
 to create a copy of a workspace directory that can be safely modified by an integration test.
 
-To use the utility, add `@contrib_rules_bazel_integration_test//tools:create_scratch_dir` as
+To use the utility, add `@rules_bazel_integration_test//tools:create_scratch_dir` as
 a dependency to your test runner binary target:
 
 ```python
@@ -48,7 +48,7 @@ sh_binary(
     testonly = True,
     srcs = ["use_create_scratch_dir_test.sh"],
     data = [
-        "@contrib_rules_bazel_integration_test//tools:create_scratch_dir",
+        "@rules_bazel_integration_test//tools:create_scratch_dir",
     ],
     deps = [
         "@bazel_tools//tools/bash/runfiles",
@@ -61,7 +61,7 @@ In your test runner code, you will need to locate the utility. Bazel provides he
 locating dependencies in shell binaries.
 
 ```bash
-create_scratch_dir_sh_location=contrib_rules_bazel_integration_test/tools/create_scratch_dir.sh
+create_scratch_dir_sh_location=rules_bazel_integration_test/tools/create_scratch_dir.sh
 create_scratch_dir_sh="$(rlocation "${create_scratch_dir_sh_location}")" || \
   (echo >&2 "Failed to locate ${create_scratch_dir_sh_location}" && exit 1)
 ```

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -72,7 +72,7 @@ sh_binary(
     testonly = True,
     srcs = ["use_create_scratch_dir_test.sh"],
     data = [
-        "@contrib_rules_bazel_integration_test//tools:create_scratch_dir",
+        "@rules_bazel_integration_test//tools:create_scratch_dir",
     ],
     deps = [
         "@bazel_tools//tools/bash/runfiles",

--- a/examples/custom_test_runner/.bazelrc
+++ b/examples/custom_test_runner/.bazelrc
@@ -1,5 +1,5 @@
 # To update these lines, execute 
-# `bazel run @contrib_rules_bazel_integration_test//tools:update_deleted_packages`
+# `bazel run @rules_bazel_integration_test//tools:update_deleted_packages`
 build --deleted_packages=integration_tests/workspace
 query --deleted_packages=integration_tests/workspace
 

--- a/examples/custom_test_runner/BUILD.bazel
+++ b/examples/custom_test_runner/BUILD.bazel
@@ -2,7 +2,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_swift_bazel//swiftpkg:defs.bzl", "swift_update_packages")
 load(
-    "@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "integration_test_utils",
 )
 

--- a/examples/custom_test_runner/WORKSPACE
+++ b/examples/custom_test_runner/WORKSPACE
@@ -3,11 +3,11 @@ workspace(name = "custom_test_runner_example")
 # MARK: - rules_bazel_integration_test
 
 local_repository(
-    name = "contrib_rules_bazel_integration_test",
+    name = "rules_bazel_integration_test",
     path = "../..",
 )
 
-load("@contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
+load("@rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 
 bazel_integration_test_rules_dependencies()
 
@@ -19,7 +19,7 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-load("@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
+load("@rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
 
 bazel_binaries(versions = SUPPORTED_BAZEL_VERSIONS)

--- a/examples/custom_test_runner/integration_tests/BUILD.bazel
+++ b/examples/custom_test_runner/integration_tests/BUILD.bazel
@@ -1,5 +1,5 @@
 load(
-    "@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "bazel_integration_test",
 )
 load("//:bazel_versions.bzl", "CURRENT_BAZEL_VERSION")

--- a/examples/use_create_scratch_dir_test.sh
+++ b/examples/use_create_scratch_dir_test.sh
@@ -16,7 +16,7 @@ assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
-create_scratch_dir_sh_location=contrib_rules_bazel_integration_test/tools/create_scratch_dir.sh
+create_scratch_dir_sh_location=rules_bazel_integration_test/tools/create_scratch_dir.sh
 create_scratch_dir_sh="$(rlocation "${create_scratch_dir_sh_location}")" || \
   (echo >&2 "Failed to locate ${create_scratch_dir_sh_location}" && exit 1)
 

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -18,7 +18,7 @@ generate_workspace_snippet(
     name = "generate_workspace_snippet",
     sha256_file = ":archive_sha256",
     template = "workspace_snippet.tmpl",
-    workspace_name = "contrib_rules_bazel_integration_test",
+    workspace_name = "rules_bazel_integration_test",
 )
 
 generate_release_notes(

--- a/release/workspace_snippet.tmpl
+++ b/release/workspace_snippet.tmpl
@@ -1,6 +1,6 @@
 ${http_archive_statement}
 
-load("@contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
+load("@rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 
 bazel_integration_test_rules_dependencies()
 

--- a/tests/tools_tests/create_scratch_dir_test.sh
+++ b/tests/tools_tests/create_scratch_dir_test.sh
@@ -14,7 +14,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 assertions_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/assertions.sh)"
 source "${assertions_lib}"
 
-create_scratch_dir_sh_location=contrib_rules_bazel_integration_test/tools/create_scratch_dir.sh
+create_scratch_dir_sh_location=rules_bazel_integration_test/tools/create_scratch_dir.sh
 create_scratch_dir_sh="$(rlocation "${create_scratch_dir_sh_location}")" || \
   (echo >&2 "Failed to locate ${create_scratch_dir_sh_location}" && exit 1)
 

--- a/tests/tools_tests/find_child_workspace_packages_test.sh
+++ b/tests/tools_tests/find_child_workspace_packages_test.sh
@@ -14,7 +14,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 assertions_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/assertions.sh)"
 source "${assertions_lib}"
 
-find_bin="$(rlocation contrib_rules_bazel_integration_test/tools/find_child_workspace_packages.sh)"
+find_bin="$(rlocation rules_bazel_integration_test/tools/find_child_workspace_packages.sh)"
 
 # MARK - Execute without a workspace
 
@@ -35,7 +35,7 @@ rm -rf "${empty_example_workspace_dir}"
 # MARK - Execute with a workspace
 
 # Set up the parent workspace
-setup_test_workspace_sh_location=contrib_rules_bazel_integration_test/tests/tools_tests/setup_test_workspace.sh
+setup_test_workspace_sh_location=rules_bazel_integration_test/tests/tools_tests/setup_test_workspace.sh
 setup_test_workspace_sh="$(rlocation "${setup_test_workspace_sh_location}")" || \
   (echo >&2 "Failed to locate ${setup_test_workspace_sh_location}" && exit 1)
 source "${setup_test_workspace_sh}"

--- a/tests/tools_tests/remove_child_wksp_bazel_symlinks_test.sh
+++ b/tests/tools_tests/remove_child_wksp_bazel_symlinks_test.sh
@@ -19,12 +19,12 @@ assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
-remove_child_wksp_bazel_symlinks_sh_location=contrib_rules_bazel_integration_test/tools/remove_child_wksp_bazel_symlinks.sh
+remove_child_wksp_bazel_symlinks_sh_location=rules_bazel_integration_test/tools/remove_child_wksp_bazel_symlinks.sh
 remove_child_wksp_bazel_symlinks_sh="$(rlocation "${remove_child_wksp_bazel_symlinks_sh_location}")" || \
   (echo >&2 "Failed to locate ${remove_child_wksp_bazel_symlinks_sh_location}" && exit 1)
 
 # Set up the parent workspace
-setup_test_workspace_sh_location=contrib_rules_bazel_integration_test/tests/tools_tests/setup_test_workspace.sh
+setup_test_workspace_sh_location=rules_bazel_integration_test/tests/tools_tests/setup_test_workspace.sh
 setup_test_workspace_sh="$(rlocation "${setup_test_workspace_sh_location}")" || \
   (echo >&2 "Failed to locate ${setup_test_workspace_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/setup_test_workspace.sh

--- a/tests/tools_tests/update_deleted_packages_test.sh
+++ b/tests/tools_tests/update_deleted_packages_test.sh
@@ -14,13 +14,13 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 assertions_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/assertions.sh)"
 source "${assertions_lib}"
 
-update_bin="$(rlocation contrib_rules_bazel_integration_test/tools/update_deleted_packages.sh)"
+update_bin="$(rlocation rules_bazel_integration_test/tools/update_deleted_packages.sh)"
 
 starting_path="${PWD}"
 
 
 # Set up the parent workspace
-setup_test_workspace_sh_location=contrib_rules_bazel_integration_test/tests/tools_tests/setup_test_workspace.sh
+setup_test_workspace_sh_location=rules_bazel_integration_test/tests/tools_tests/setup_test_workspace.sh
 setup_test_workspace_sh="$(rlocation "${setup_test_workspace_sh_location}")" || \
   (echo >&2 "Failed to locate ${setup_test_workspace_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/setup_test_workspace.sh

--- a/tools/find_child_workspace_packages.sh
+++ b/tools/find_child_workspace_packages.sh
@@ -29,7 +29,7 @@ fail_sh="$(rlocation "${fail_sh_location}")" || \
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 source "${fail_sh}"
 
-shared_fns_sh_location=contrib_rules_bazel_integration_test/tools/shared_fns.sh
+shared_fns_sh_location=rules_bazel_integration_test/tools/shared_fns.sh
 shared_fns_sh="$(rlocation "${shared_fns_sh_location}")" || \
   (echo >&2 "Failed to locate ${shared_fns_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/shared_fns.sh

--- a/tools/remove_child_wksp_bazel_symlinks.sh
+++ b/tools/remove_child_wksp_bazel_symlinks.sh
@@ -23,7 +23,7 @@ files_sh="$(rlocation "${files_sh_location}")" || \
   (echo >&2 "Failed to locate ${files_sh_location}" && exit 1)
 source "${files_sh}"
 
-shared_fns_sh_location=contrib_rules_bazel_integration_test/tools/shared_fns.sh
+shared_fns_sh_location=rules_bazel_integration_test/tools/shared_fns.sh
 shared_fns_sh="$(rlocation "${shared_fns_sh_location}")" || \
   (echo >&2 "Failed to locate ${shared_fns_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/shared_fns.sh

--- a/tools/update_deleted_packages.sh
+++ b/tools/update_deleted_packages.sh
@@ -26,7 +26,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-find_pkgs_script="$(rlocation contrib_rules_bazel_integration_test/tools/find_child_workspace_packages.sh)"
+find_pkgs_script="$(rlocation rules_bazel_integration_test/tools/find_child_workspace_packages.sh)"
 
 messages_sh_location=cgrindel_bazel_starlib/shlib/lib/messages.sh
 messages_sh="$(rlocation "${messages_sh_location}")" || \


### PR DESCRIPTION
- Rename `contrib_rules_bazel_integration_test` to `rules_bazel_integration_test`.

Related to #120.