### PR TITLE
chore: implement hub-and-spoke for bazel binary downloads

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,3 @@
+fixedReleaser:
+  login: cgrindel
+  email: chuck.grindel@gmail.com

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,15 @@
+{
+  "homepage": "https://github.com/bazel-contrib/rules_bazel_integration_test",
+  "maintainers": [
+    {
+      "email": "chuck.grindel@gmail.com",
+      "github": "cgrindel",
+      "name": "Chuck Grindel"
+    }
+  ],
+  "repository": [
+    "github:bazel-contrib/rules_bazel_integration_test"
+  ],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,10 @@
+bcr_test_module:
+  module_path: "examples/simple"
+  matrix:
+    platform: ["macos", "ubuntu2004"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_bazel_integration_test.{TAG}.tar.gz"
+}

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -66,6 +66,7 @@ filegroup(
         ":shared_bazelrc_files",
         "//bazel_integration_test:all_files",
         "//bazel_integration_test/private:all_files",
+        "//examples:all_files",
         "//tools:all_files",
     ],
     visibility = ["//:__subpackages__"],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,12 +16,4 @@ bazel_binaries = use_extension("//:extensions.bzl", "bazel_binaries")
 bazel_binaries.download(version_file = "//:.bazelversion")
 bazel_binaries.download(version = "7.0.0-pre.20230215.2")
 bazel_binaries.rbt_repo(name = "")
-use_repo(
-    bazel_binaries,
-    "bazel_binaries",
-)
-# use_repo(
-#     bazel_binaries,
-#     "build_bazel_bazel_.bazelversion",
-#     "build_bazel_bazel_7_0_0-pre_20230215_2",
-# )
+use_repo(bazel_binaries, "bazel_binaries")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,11 @@ register_toolchains("@bazel_tools//tools/python:autodetecting_toolchain")
 
 # GH125: Must keep the Bazel version listed in bazel_versions.bzl in sync with
 # those loaded below.
-bazel_binaries = use_extension("//:extensions.bzl", "bazel_binaries")
+bazel_binaries = use_extension(
+    "//:extensions.bzl",
+    "bazel_binaries",
+    dev_dependency = True,
+)
 bazel_binaries.download(version_file = "//:.bazelversion")
 bazel_binaries.download(version = "7.0.0-pre.20230215.2")
 bazel_binaries.rbt_repo(name = "")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,8 +15,13 @@ register_toolchains("@bazel_tools//tools/python:autodetecting_toolchain")
 bazel_binaries = use_extension("//:extensions.bzl", "bazel_binaries")
 bazel_binaries.download(version_file = "//:.bazelversion")
 bazel_binaries.download(version = "7.0.0-pre.20230215.2")
+bazel_binaries.rbt_repo(name = "")
 use_repo(
     bazel_binaries,
-    "build_bazel_bazel_.bazelversion",
-    "build_bazel_bazel_7_0_0-pre_20230215_2",
+    "bazel_binaries",
 )
+# use_repo(
+#     bazel_binaries,
+#     "build_bazel_bazel_.bazelversion",
+#     "build_bazel_bazel_7_0_0-pre_20230215_2",
+# )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,6 +30,15 @@ buildifier_prebuilt_register_toolchains()
 
 # MARK: - Integration Tests
 
+load("//bazel_integration_test/bzlmod:workspace_bazel_binaries.bzl", "workspace_bazel_binaries")
+
+# This is only necessary while rules_bazel_integration_test switches back and
+# forth between WORKSPACE repositories and bzlmod repositories.
+workspace_bazel_binaries(
+    name = "bazel_binaries",
+    rbt_repo_name = "",
+)
+
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
 load("//bazel_integration_test:defs.bzl", "bazel_binaries")
 

--- a/bazel_integration_test/bzlmod/bazel_binaries.bzl
+++ b/bazel_integration_test/bzlmod/bazel_binaries.bzl
@@ -9,7 +9,6 @@ load("//bazel_integration_test/private:no_deps_utils.bzl", "no_deps_utils")
 # MARK: - bazel_binaries_helper Repository Rule
 
 _BAZEL_BINARIES_HELPER_DEFS_BZL = """load("@{rbt_repo_name}//bazel_integration_test/bzlmod:bazel_binary_utils.bzl", "bazel_binary_utils")
-load("@{rbt_repo_name}//bazel_integration_test/private:no_deps_utils.bzl", "no_deps_utils")
 
 def _label(version):
     return bazel_binary_utils.label(_VERSIONS, version, lambda x: Label(x))

--- a/bazel_integration_test/bzlmod/bazel_binaries.bzl
+++ b/bazel_integration_test/bzlmod/bazel_binaries.bzl
@@ -6,6 +6,31 @@ load(
 )
 load("//bazel_integration_test/private:no_deps_utils.bzl", "no_deps_utils")
 
+# MARK: - bazel_binaries_helper Repository Rule
+
+_BAZEL_BINARIES_HELPER_DEFS_BZL = """load("@rule_bazel_integration_test//bazel_integration_test/private:no_deps_utils.bzl", "no_deps_utils")
+
+def repo_name(version):
+    return no_deps_utils.bazel_binary_repo_name(version)
+
+_VERSIONS = {}
+"""
+
+def _bazel_binaries_helper_impl(repository_ctx):
+    pass
+
+_bazel_binaries_helper = repository_rule(
+    implementation = _bazel_binaries_helper_impl,
+    attrs = {
+        "versions": attr.string_dict(
+            doc = "A mapping of version number/reference to repository name.",
+            mandatory = True,
+        ),
+    },
+)
+
+# MARK: - bazel_binaries Extension
+
 def _declare_bazel_binary(download):
     if download.version != "" and download.version_file != None:
         fail("""\

--- a/bazel_integration_test/bzlmod/bazel_binaries.bzl
+++ b/bazel_integration_test/bzlmod/bazel_binaries.bzl
@@ -21,14 +21,6 @@ bazel_binaries = struct(
 )
 """
 
-# _BAZEL_BINARIES_HELPER_DEFS_BZL = """load("@rule_bazel_integration_test//bazel_integration_test/private:no_deps_utils.bzl", "no_deps_utils")
-#
-# def repo_name(version):
-#     return no_deps_utils.bazel_binary_repo_name(version)
-#
-# _VERSIONS = {}
-# """
-
 def _bazel_binaries_helper_impl(repository_ctx):
     repository_ctx.file("defs.bzl", _BAZEL_BINARIES_HELPER_DEFS_BZL.format(
         versions = repository_ctx.attr.versions,
@@ -49,6 +41,7 @@ _bazel_binaries_helper = repository_rule(
             mandatory = True,
         ),
     },
+    doc = "Hub repository that resolves Bazel versions to Bazel labels.",
 )
 
 # MARK: - bazel_binaries Extension
@@ -94,6 +87,11 @@ _rbt_repo_tag = tag_class(
             doc = "The name of the rules_bazel_integration_test repository.",
         ),
     },
+    doc = """\
+For internal use only. Allow a client to specify the name of the \
+`rules_bazel_integration_test` repository. The only repository that should use \
+this tag class is `rules_bazel_integration_test`.\
+""",
 )
 
 _download_tag = tag_class(
@@ -111,9 +109,17 @@ string.\
 """,
         ),
     },
+    doc = """\
+Identifies Bazel versions that will be downloaded and made available for \
+`bazel_integration_test`.\
+""",
 )
 
 bazel_binaries = module_extension(
     implementation = _bazel_binaries_impl,
     tag_classes = {"download": _download_tag, "rbt_repo": _rbt_repo_tag},
+    doc = """\
+Provides a means for clients to download Bazel binaries for their integration \
+tests.\
+""",
 )

--- a/bazel_integration_test/bzlmod/bazel_binary_utils.bzl
+++ b/bazel_integration_test/bzlmod/bazel_binary_utils.bzl
@@ -7,14 +7,19 @@ def _repo_name(version_to_repo_name, version):
         # Fallback to original behavior.
         return no_deps_utils.bazel_binary_repo_name(version)
     if no_deps_utils.is_version_file(version):
+        if not version.startswith("@"):
+            version = "@@{}".format(version)
         version_str = str(Label(version))
     else:
         version_str = version
     repo_name = version_to_repo_name.get(version_str, None)
     if repo_name == None:
         fail("""\
-Failed to find a Bazel binary registered for version '{}'.\
-""".format(version))
+Failed to find a Bazel binary registered for version '{version}' ({version_str}).\
+""".format(
+            version = version,
+            version_str = version_str,
+        ))
     return repo_name
 
 def _label(version_to_repo_name, version, canonicalize):

--- a/bazel_integration_test/bzlmod/bazel_binary_utils.bzl
+++ b/bazel_integration_test/bzlmod/bazel_binary_utils.bzl
@@ -22,6 +22,5 @@ def _label(version_to_repo_name, version, canonicalize):
     return canonicalize(no_deps_utils.bazel_binary_label(repo_name))
 
 bazel_binary_utils = struct(
-    repo_name = _repo_name,
     label = _label,
 )

--- a/bazel_integration_test/bzlmod/bazel_binary_utils.bzl
+++ b/bazel_integration_test/bzlmod/bazel_binary_utils.bzl
@@ -1,0 +1,27 @@
+"""Module for resolving repository names for Bazel binaries."""
+
+load("//bazel_integration_test/private:no_deps_utils.bzl", "no_deps_utils")
+
+def _repo_name(version_to_repo_name, version):
+    if len(version_to_repo_name) == 0:
+        # Fallback to original behavior.
+        return no_deps_utils.bazel_binary_repo_name(version)
+    if no_deps_utils.is_version_file(version):
+        version_str = str(Label(version))
+    else:
+        version_str = version
+    repo_name = version_to_repo_name.get(version_str, None)
+    if repo_name == None:
+        fail("""\
+Failed to find a Bazel binary registered for version '{}'.\
+""".format(version))
+    return repo_name
+
+def _label(version_to_repo_name, version, canonicalize):
+    repo_name = _repo_name(version_to_repo_name, version)
+    return canonicalize(no_deps_utils.bazel_binary_label(repo_name))
+
+bazel_binary_utils = struct(
+    repo_name = _repo_name,
+    label = _label,
+)

--- a/bazel_integration_test/bzlmod/workspace_bazel_binaries.bzl
+++ b/bazel_integration_test/bzlmod/workspace_bazel_binaries.bzl
@@ -1,3 +1,5 @@
+"""Implementation for `workspace_bazel_binaries`."""
+
 _BAZEL_BINARIES_HELPER_DEFS_BZL = """load("@{rbt_repo_name}//bazel_integration_test/private:integration_test_utils.bzl", "integration_test_utils")
 
 bazel_binaries = struct(

--- a/bazel_integration_test/bzlmod/workspace_bazel_binaries.bzl
+++ b/bazel_integration_test/bzlmod/workspace_bazel_binaries.bzl
@@ -1,0 +1,28 @@
+_BAZEL_BINARIES_HELPER_DEFS_BZL = """load("@{rbt_repo_name}//bazel_integration_test/private:integration_test_utils.bzl", "integration_test_utils")
+
+bazel_binaries = struct(
+    label = integration_test_utils.bazel_binary_label,
+)
+"""
+
+def _workspace_bazel_binaries_impl(repository_ctx):
+    repository_ctx.file("defs.bzl", _BAZEL_BINARIES_HELPER_DEFS_BZL.format(
+        rbt_repo_name = repository_ctx.attr.rbt_repo_name,
+    ))
+    repository_ctx.file("WORKSPACE")
+    repository_ctx.file("BUILD.bazel")
+
+workspace_bazel_binaries = repository_rule(
+    implementation = _workspace_bazel_binaries_impl,
+    attrs = {
+        "rbt_repo_name": attr.string(
+            doc = "The name of the rules_bazel_integration_test repo.",
+            default = "rules_bazel_integration_test",
+        ),
+    },
+    doc = """\
+Provides a default implementation for a `bazel_binaries` repository. This is \
+only necessary for repositories that switch back and forth between WORKSPACE \
+repositories and bzlmod repositories.\
+""",
+)

--- a/bazel_integration_test/private/bazel_integration_test.bzl
+++ b/bazel_integration_test/private/bazel_integration_test.bzl
@@ -90,6 +90,11 @@ def bazel_integration_test(
                      values.
         additional_env_inherit: Optional. Specify additional `env_inherit`
                                 values that should be passed to the test.
+        bazel_binaries: Optional for WORKSPACE loaded repositories. Required
+            for repositories that enable bzlmod. The value for this parameter
+            is loaded by adding
+            `load("@bazel_binaries//:defs.bzl", "bazel_binaries")` to your
+            build file.
         **kwargs: additional attributes like timeout and visibility
     """
 
@@ -212,6 +217,11 @@ def bazel_integration_tests(
                      values.
         additional_env_inherit: Optional. Specify additional `env_inherit`
                                 values that should be passed to the test.
+        bazel_binaries: Optional for WORKSPACE loaded repositories. Required
+            for repositories that enable bzlmod. The value for this parameter
+            is loaded by adding
+            `load("@bazel_binaries//:defs.bzl", "bazel_binaries")` to your
+            build file.
         **kwargs: additional attributes like timeout and visibility
     """
     if bazel_versions == []:

--- a/bazel_integration_test/private/bazel_integration_test.bzl
+++ b/bazel_integration_test/private/bazel_integration_test.bzl
@@ -48,6 +48,7 @@ def bazel_integration_test(
         env = {},
         env_inherit = _DEFAULT_ENV_INHERIT,
         additional_env_inherit = [],
+        bazel_binaries = None,
         **kwargs):
     """Macro that defines a set of targets for a single Bazel integration test.
 
@@ -95,7 +96,10 @@ def bazel_integration_test(
     if bazel_binary == None and bazel_version == None:
         fail("The `bazel_binary` or the `bazel_version` must be specified.")
     if bazel_binary == None:
-        bazel_binary = integration_test_utils.bazel_binary_label(bazel_version)
+        # bazel_binary = integration_test_utils.bazel_binary_label(bazel_version)
+        if bazel_binaries == None:
+            fail("Need to specify a `bazel_binaries` to resolve the Bazel version.")
+        bazel_binary = bazel_binaries.label(bazel_version)
 
     # Find the Bazel binary
     bazel_bin_name = name + "_bazel_binary"
@@ -178,6 +182,7 @@ def bazel_integration_tests(
         timeout = "long",
         env_inherit = _DEFAULT_ENV_INHERIT,
         additional_env_inherit = [],
+        bazel_binaries = None,
         **kwargs):
     """Macro that defines a set Bazel integration tests each executed with a different version of Bazel.
 
@@ -222,5 +227,6 @@ def bazel_integration_tests(
             timeout = timeout,
             env_inherit = env_inherit,
             additional_env_inherit = additional_env_inherit,
+            bazel_binaries = bazel_binaries,
             **kwargs
         )

--- a/bazel_integration_test/private/bazel_integration_test.bzl
+++ b/bazel_integration_test/private/bazel_integration_test.bzl
@@ -93,12 +93,16 @@ def bazel_integration_test(
         **kwargs: additional attributes like timeout and visibility
     """
 
+    # To support clients that have not transitioned to bzlmod, we provide a
+    # bazel_binaries implementation that works in that mode. If a client using
+    # bzlmod does not specify bazel_binaries, things will go badly for them.
+    if bazel_binaries == None:
+        bazel_binaries = struct(
+            label = integration_test_utils.bazel_binary_label,
+        )
     if bazel_binary == None and bazel_version == None:
         fail("The `bazel_binary` or the `bazel_version` must be specified.")
     if bazel_binary == None:
-        # bazel_binary = integration_test_utils.bazel_binary_label(bazel_version)
-        if bazel_binaries == None:
-            fail("Need to specify a `bazel_binaries` to resolve the Bazel version.")
         bazel_binary = bazel_binaries.label(bazel_version)
 
     # Find the Bazel binary

--- a/bazel_integration_test/private/integration_test_utils.bzl
+++ b/bazel_integration_test/private/integration_test_utils.bzl
@@ -16,7 +16,7 @@ def _bazel_binary_label(version):
         A `string` representing a label for a version of Bazel.
     """
     repo_name = no_deps_utils.bazel_binary_repo_name(version)
-    return "@{repo_name}//:bazel_binary".format(repo_name = repo_name)
+    return no_deps_utils.bazel_binary_label(repo_name)
 
 def _bazel_integration_test_name(name, version):
     """Generates a test name from the provided base name and the Bazel version.

--- a/bazel_integration_test/private/no_deps_utils.bzl
+++ b/bazel_integration_test/private/no_deps_utils.bzl
@@ -55,8 +55,12 @@ def _is_version_file(version):
     """
     return version.find("//") > -1
 
+def _bazel_binary_label(repo_name):
+    return "@{repo_name}//:bazel_binary".format(repo_name = repo_name)
+
 no_deps_utils = struct(
     bazel_binary_repo_name = _bazel_binary_repo_name,
+    bazel_binary_label = _bazel_binary_label,
     is_version_file = _is_version_file,
     normalize_version = _normalize_version,
     semantic_version_to_name = _semantic_version_to_name,

--- a/bazel_integration_test/py/bazel_py_integration_tests.bzl
+++ b/bazel_integration_test/py/bazel_py_integration_tests.bzl
@@ -3,7 +3,14 @@
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//bazel_integration_test:defs.bzl", "bazel_integration_tests")
 
-def bazel_py_integration_tests(name, srcs, bazel_versions, main = None, deps = [], env = {}):
+def bazel_py_integration_tests(
+        name,
+        srcs,
+        bazel_versions,
+        main = None,
+        deps = [],
+        env = {},
+        bazel_binaries = None):
     # Declare the test runner
     runner_name = name
     py_binary(
@@ -19,6 +26,7 @@ def bazel_py_integration_tests(name, srcs, bazel_versions, main = None, deps = [
     # Declare the integration tests.
     bazel_integration_tests(
         name = name,
+        bazel_binaries = bazel_binaries,
         bazel_versions = bazel_versions,
         test_runner = runner_name,
         env = env,

--- a/doc/rules_and_macros_overview.md
+++ b/doc/rules_and_macros_overview.md
@@ -18,7 +18,7 @@ On this page:
 <pre>
 bazel_integration_test(<a href="#bazel_integration_test-name">name</a>, <a href="#bazel_integration_test-test_runner">test_runner</a>, <a href="#bazel_integration_test-bazel_version">bazel_version</a>, <a href="#bazel_integration_test-bazel_binary">bazel_binary</a>, <a href="#bazel_integration_test-workspace_path">workspace_path</a>,
                        <a href="#bazel_integration_test-workspace_files">workspace_files</a>, <a href="#bazel_integration_test-tags">tags</a>, <a href="#bazel_integration_test-timeout">timeout</a>, <a href="#bazel_integration_test-env">env</a>, <a href="#bazel_integration_test-env_inherit">env_inherit</a>, <a href="#bazel_integration_test-additional_env_inherit">additional_env_inherit</a>,
-                       <a href="#bazel_integration_test-kwargs">kwargs</a>)
+                       <a href="#bazel_integration_test-bazel_binaries">bazel_binaries</a>, <a href="#bazel_integration_test-kwargs">kwargs</a>)
 </pre>
 
 Macro that defines a set of targets for a single Bazel integration test.
@@ -49,6 +49,7 @@ default test runner is provided by the `default_test_runner` macro.
 | <a id="bazel_integration_test-env"></a>env |  Optional. A dictionary of <code>strings</code>. Specifies additional environment variables to be passed to the test.   |  <code>{}</code> |
 | <a id="bazel_integration_test-env_inherit"></a>env_inherit |  Optional. Override the env_inherit values passed to the test. Only do this if you understand what needs to be passed along. Most folks will want to use <code>additional_env_inherit</code> to pass additional env_inherit values.   |  <code>["SUDO_ASKPASS", "HOME", "CC"]</code> |
 | <a id="bazel_integration_test-additional_env_inherit"></a>additional_env_inherit |  Optional. Specify additional <code>env_inherit</code> values that should be passed to the test.   |  <code>[]</code> |
+| <a id="bazel_integration_test-bazel_binaries"></a>bazel_binaries |  <p align="center"> - </p>   |  <code>None</code> |
 | <a id="bazel_integration_test-kwargs"></a>kwargs |  additional attributes like timeout and visibility   |  none |
 
 
@@ -58,7 +59,7 @@ default test runner is provided by the `default_test_runner` macro.
 
 <pre>
 bazel_integration_tests(<a href="#bazel_integration_tests-name">name</a>, <a href="#bazel_integration_tests-test_runner">test_runner</a>, <a href="#bazel_integration_tests-bazel_versions">bazel_versions</a>, <a href="#bazel_integration_tests-workspace_path">workspace_path</a>, <a href="#bazel_integration_tests-workspace_files">workspace_files</a>, <a href="#bazel_integration_tests-tags">tags</a>,
-                        <a href="#bazel_integration_tests-timeout">timeout</a>, <a href="#bazel_integration_tests-env_inherit">env_inherit</a>, <a href="#bazel_integration_tests-additional_env_inherit">additional_env_inherit</a>, <a href="#bazel_integration_tests-kwargs">kwargs</a>)
+                        <a href="#bazel_integration_tests-timeout">timeout</a>, <a href="#bazel_integration_tests-env_inherit">env_inherit</a>, <a href="#bazel_integration_tests-additional_env_inherit">additional_env_inherit</a>, <a href="#bazel_integration_tests-bazel_binaries">bazel_binaries</a>, <a href="#bazel_integration_tests-kwargs">kwargs</a>)
 </pre>
 
 Macro that defines a set Bazel integration tests each executed with a different version of Bazel.
@@ -77,6 +78,7 @@ Macro that defines a set Bazel integration tests each executed with a different 
 | <a id="bazel_integration_tests-timeout"></a>timeout |  A valid Bazel timeout value. https://docs.bazel.build/versions/main/test-encyclopedia.html#role-of-the-test-runner   |  <code>"long"</code> |
 | <a id="bazel_integration_tests-env_inherit"></a>env_inherit |  Optional. Override the env_inherit values passed to the test. Only do this if you understand what needs to be passed along. Most folks will want to use <code>additional_env_inherit</code> to pass additional env_inherit values.   |  <code>["SUDO_ASKPASS", "HOME", "CC"]</code> |
 | <a id="bazel_integration_tests-additional_env_inherit"></a>additional_env_inherit |  Optional. Specify additional <code>env_inherit</code> values that should be passed to the test.   |  <code>[]</code> |
+| <a id="bazel_integration_tests-bazel_binaries"></a>bazel_binaries |  <p align="center"> - </p>   |  <code>None</code> |
 | <a id="bazel_integration_tests-kwargs"></a>kwargs |  additional attributes like timeout and visibility   |  none |
 
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -143,3 +143,11 @@ test_suite(
     ),
     visibility = ["//:__subpackages__"],
 )
+
+# We do not want to pull everything into the release archive. We just need the
+# bzlmod_e2e workspace.
+filegroup(
+    name = "all_files",
+    srcs = glob(["simple/**"]),
+    visibility = ["//:__subpackages__"],
+)

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_binaries//:defs.bzl", "bazel_binaries")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//:bazel_versions.bzl", "CURRENT_BAZEL_VERSION", "OTHER_BAZEL_VERSIONS")
 load(
@@ -20,6 +21,7 @@ default_test_runner(
 # bazel_integration_test.
 bazel_integration_test(
     name = "simple_test",
+    bazel_binaries = bazel_binaries,
     bazel_version = CURRENT_BAZEL_VERSION,
     test_runner = ":simple_test_runner",
     workspace_files = integration_test_utils.glob_workspace_files("simple") + [
@@ -34,6 +36,7 @@ bazel_integration_test(
 bazel_integration_tests(
     # buildifier: disable=duplicated-name
     name = "simple_test",
+    bazel_binaries = bazel_binaries,
     bazel_versions = OTHER_BAZEL_VERSIONS,
     test_runner = ":simple_test_runner",
     workspace_files = integration_test_utils.glob_workspace_files("simple") + [
@@ -57,6 +60,7 @@ default_test_runner(
 
 bazel_integration_test(
     name = "custom_test_runner_test",
+    bazel_binaries = bazel_binaries,
     bazel_version = CURRENT_BAZEL_VERSION,
     # GH120: Enable the custom_test_runner test once swift_bazel supports
     # bzlmod.
@@ -88,6 +92,7 @@ sh_binary(
 
 bazel_integration_test(
     name = "use_create_scratch_dir_test",
+    bazel_binaries = bazel_binaries,
     bazel_version = CURRENT_BAZEL_VERSION,
     test_runner = ":use_create_scratch_dir_test_runner",
     workspace_files = integration_test_utils.glob_workspace_files("simple") + [
@@ -110,6 +115,7 @@ sh_binary(
 
 bazel_integration_test(
     name = "dynamic_workspace_test",
+    bazel_binaries = bazel_binaries,
     bazel_version = CURRENT_BAZEL_VERSION,
     test_runner = ":dynamic_workspace_test_runner",
 )

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -145,7 +145,7 @@ test_suite(
 )
 
 # We do not want to pull everything into the release archive. We just need the
-# bzlmod_e2e workspace.
+# simple workspace.
 filegroup(
     name = "all_files",
     srcs = glob(["simple/**"]),

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -10,6 +10,9 @@ build --incompatible_disallow_empty_glob
 # Pretty output
 common --color=auto --curses=auto
 
-# Enable bzlmod
-common --enable_bzlmod
-build --@cgrindel_bazel_starlib//bzlmod:enabled
+# # Enable bzlmod
+# common --enable_bzlmod
+# build --@cgrindel_bazel_starlib//bzlmod:enabled
+
+common --noenable_bzlmod
+build --no@cgrindel_bazel_starlib//bzlmod:enabled

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -10,9 +10,11 @@ build --incompatible_disallow_empty_glob
 # Pretty output
 common --color=auto --curses=auto
 
-# # Enable bzlmod
-# common --enable_bzlmod
-# build --@cgrindel_bazel_starlib//bzlmod:enabled
+# Enable bzlmod
+common --enable_bzlmod
+build --@cgrindel_bazel_starlib//bzlmod:enabled
 
-common --noenable_bzlmod
-build --no@cgrindel_bazel_starlib//bzlmod:enabled
+# TODO: FIX ME
+#
+# common --noenable_bzlmod
+# build --no@cgrindel_bazel_starlib//bzlmod:enabled

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -13,8 +13,3 @@ common --color=auto --curses=auto
 # Enable bzlmod
 common --enable_bzlmod
 build --@cgrindel_bazel_starlib//bzlmod:enabled
-
-# TODO: FIX ME
-#
-# common --noenable_bzlmod
-# build --no@cgrindel_bazel_starlib//bzlmod:enabled

--- a/tests/params_tests/BUILD.bazel
+++ b/tests/params_tests/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_binaries//:defs.bzl", "bazel_binaries")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//:bazel_versions.bzl", "CURRENT_BAZEL_VERSION")
 load(
@@ -18,6 +19,7 @@ default_test_runner(
 
 bazel_integration_test(
     name = "default_env_inherit_int_test",
+    bazel_binaries = bazel_binaries,
     bazel_version = CURRENT_BAZEL_VERSION,
     test_runner = ":test_runner",
     workspace_path = "workspace",
@@ -36,6 +38,7 @@ env_inherit_attr_test(
 
 bazel_integration_test(
     name = "override_env_inherit_int_test",
+    bazel_binaries = bazel_binaries,
     bazel_version = CURRENT_BAZEL_VERSION,
     env_inherit = [
         "HOME",
@@ -64,6 +67,7 @@ bazel_integration_test(
     additional_env_inherit = [
         "CHICKEN",
     ],
+    bazel_binaries = bazel_binaries,
     bazel_version = CURRENT_BAZEL_VERSION,
     test_runner = ":test_runner",
     workspace_path = "workspace",

--- a/tests/py_tests/BUILD.bazel
+++ b/tests/py_tests/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_binaries//:defs.bzl", "bazel_binaries")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
 load("//bazel_integration_test:defs.bzl", "integration_test_utils")
@@ -8,6 +9,7 @@ bzlformat_pkg(name = "bzlformat")
 bazel_py_integration_tests(
     name = "test_base_test",
     srcs = ["test_base_test.py"],
+    bazel_binaries = bazel_binaries,
     bazel_versions = SUPPORTED_BAZEL_VERSIONS,
 )
 


### PR DESCRIPTION
- Add `.bcr` folder with requisite files.
- Generate hub repository to aid in the resolution of the  Bazel binary repositories.
- Add `workspace_bazel_binaries` rule to allow repositories that use `rules_bazel_integration_test` to work with and without bzlmod enabled.

Inspired by bazelbuild/bazel-gazelle#1423.
Related to #125.