### PR TITLE
update_deleted_packages: filter out bazelignored directories

### DIFF
--- a/tools/shared_fns.sh
+++ b/tools/shared_fns.sh
@@ -1,8 +1,27 @@
 #!/usr/bin/env bash
 
+filter_bazelignored_directories() {
+  local workspace_root="${1}"
+  local path="${2}"
+
+  if [[ -f "${workspace_root}/.bazelignore" ]]; then
+    path_relative_to_workspace="${path#${workspace_root}/}"
+    bazelignore_dirs=($(grep -v '^#' "${workspace_root}/.bazelignore" | grep "."))
+    for bazelignore_dir in "${bazelignore_dirs[@]}"; do
+      if [[ "${path_relative_to_workspace}" == "${bazelignore_dir}" || "${path_relative_to_workspace}" == "${bazelignore_dir}/"* ]]; then
+        return
+      fi
+    done
+  fi
+
+  echo "${path}"
+}
+
 find_workspace_dirs() {
   local path="${1}"
   # Make sure that the -print0 is the last primary for find. Otherwise, you
   # will get undesirable results.
-  find "${path}" \( -name "WORKSPACE" -o -name "WORKSPACE.bazel" \) -print0  | xargs -0 -n 1 dirname
+  while IFS=$'\n' read -r line; do filter_bazelignored_directories "${path}" "${line}" ; done < <(
+    find "${path}" \( -name "WORKSPACE" -o -name "WORKSPACE.bazel" \) -print0  | xargs -0 -n 1 dirname
+  )
 }


### PR DESCRIPTION
These directories aren't considered by bazel in the first place, so can't be used as test workspaces, and are potentially lots of extra noise in a --deleted_packages value.