### PR TITLE
fix: ensure that bazelignore filter handles missing `.bazelignore`

### DIFF
--- a/tools/find_child_workspace_packages.sh
+++ b/tools/find_child_workspace_packages.sh
@@ -10,6 +10,7 @@
 # --- begin runfiles.bash initialization v2 ---
 # Copy-pasted from the Bazel Bash runfiles library v2.
 set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
 source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
   source "$0.runfiles/$f" 2>/dev/null || \
@@ -19,14 +20,17 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 # --- end runfiles.bash initialization v2 ---
 
 arrays_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/arrays.sh)"
+# shellcheck disable=SC1090
 source "${arrays_lib}"
 
 files_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/files.sh)"
+# shellcheck disable=SC1090
 source "${files_lib}"
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
 fail_sh="$(rlocation "${fail_sh_location}")" || \
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+# shellcheck disable=SC1090
 source "${fail_sh}"
 
 shared_fns_sh_location=rules_bazel_integration_test/tools/shared_fns.sh


### PR DESCRIPTION
- Refactor `filter_bazelignored_directories()`
  - Gracefully handle if `.bazelignore` does not exist.
  - Do not attempt to ignore if the `path` is the workspace root.
  - Address some ShellCheck warnings.
- Add test to ensure that `.bazelignore` directories are respected.
