### PR TITLE
Use a default for current version when none is specified.

### DIFF
--- a/bazel_integration_test/private/bazel_binaries.bzl
+++ b/bazel_integration_test/private/bazel_binaries.bzl
@@ -233,6 +233,8 @@ def bazel_binaries(
         else:
             bazel_binary(name = bb_name, version = version)
 
+    if not current_version:
+        current_version = all_versions[0]
     other_versions = [v for v in all_versions if v != current_version]
 
     _bazel_binaries_helper(


### PR DESCRIPTION
Currently, if you do not specify `current` and use a bazelversion file, tests run correctly. If you do not specify `current` and use a list of versions, an error occurs.