### PR TITLE
Use bazelisk to download bazels for tests, instead of trying to download

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ bazel_skylib_workspace()
 #### Recommended: Add Bazel versions to `MODULE.bazel`
 
 Load the `bazel_binaries` extension and specify the Bazel verions to download.
+All version specifiers supported by
+[Bazelisk](https://github.com/bazelbuild/bazelisk#how-does-bazelisk-know-which-bazel-version-to-run)
+are supported.
 
 ```python
 bazel_binaries = use_extension(
@@ -91,7 +94,7 @@ bazel_binaries = use_extension(
 )
 bazel_binaries.download(version_file = "//:.bazelversion")
 bazel_binaries.download(version = "6.0.0")
-bazel_binaries.download(version = "7.0.0-pre.20230215.2")
+bazel_binaries.download(version = "last_green")
 use_repo(bazel_binaries, "bazel_binaries")
 ```
 
@@ -106,7 +109,7 @@ load("@rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_bi
 bazel_binaries(versions = [
     "//:.bazelversion",
     "6.0.0",
-    "7.0.0-pre.20230215.2",
+    "last_green",
 ])
 ```
 

--- a/bazel_integration_test/bzlmod/bazel_binaries.bzl
+++ b/bazel_integration_test/bzlmod/bazel_binaries.bzl
@@ -127,7 +127,7 @@ version, version_file.\
         )
     return vi
 
-# TODO: Make this configurable.
+# TODO(GH184): Make this configurable.
 _BAZELISK_VERSION = "1.18.0"
 
 def _bazel_binaries_impl(module_ctx):

--- a/bazel_integration_test/private/bazel_binaries.bzl
+++ b/bazel_integration_test/private/bazel_binaries.bzl
@@ -7,66 +7,6 @@ load(":no_deps_utils.bzl", "no_deps_utils")
 
 # MARK: - Helpers
 
-def _get_platform_name(repository_ctx):
-    os_name = repository_ctx.os.name.lower()
-
-    if os_name.startswith("mac os"):
-        return "darwin-x86_64"
-    if os_name.startswith("windows"):
-        return "windows-x86_64"
-
-    # We default on linux-x86_64 because we only support 3 platforms
-    return "linux-x86_64"
-
-def _is_windows(repository_ctx):
-    return _get_platform_name(repository_ctx).startswith("windows")
-
-def _get_installer(repository_ctx, version):
-    platform = _get_platform_name(repository_ctx)
-
-    if _is_windows(repository_ctx):
-        extension = "zip"
-        installer = ""
-    else:
-        extension = "sh"
-        installer = "-installer"
-
-    filename = "bazel-{version}{installer}-{platform}.{extension}".format(
-        version = version,
-        installer = installer,
-        platform = platform,
-        extension = extension,
-    )
-
-    kind = "release"
-
-    # Mimics determineURL in github.com/bazelbuild/bazelisk/bazelisk.go
-    enabled_packages = [
-        "https://releases.bazel.build/{version}/{kind}/{filename}",
-    ]
-
-    if "rc" in version:
-        version_components = version.split("rc")
-        version = version_components[0]
-        kind = "rc" + version_components[1]
-    else:
-        enabled_packages.append(
-            "https://github.com/{fork}/bazel/releases/download/{version}/{filename}",
-        )
-
-    urls = [
-        url.format(
-            fork = "bazelbuild",
-            version = version,
-            kind = kind,
-            filename = filename,
-        )
-        for url in enabled_packages
-    ]
-    args = {"type": "zip", "url": urls}
-
-    repository_ctx.download_and_extract(**args)
-
 _BAZELISK_URL_TEMPLATE = "https://github.com/bazelbuild/bazelisk/releases/download/v{version}/{filename}"
 
 def _download_bazelisk_binary(repository_ctx, version):

--- a/bazel_integration_test/private/bazel_binaries.bzl
+++ b/bazel_integration_test/private/bazel_binaries.bzl
@@ -291,6 +291,8 @@ def bazel_binaries(
 
     Args:
         versions: A `list` of Bazel versions.
+        bazelisk_version: The version of Bazelisk to use for downloading Bazel
+            binaries.
         current: Optional. The version that is considered the current version.
             If not specified, a reference to a `.bazelversion` will be
             considered the current version.

--- a/bazel_integration_test/private/bazel_binaries.bzl
+++ b/bazel_integration_test/private/bazel_binaries.bzl
@@ -178,17 +178,22 @@ sh_binary(
         "bazel.sh",
         Label(":bazel_binaries_script.template"),
         substitutions = {
-            "{version}": version,
             "{bazelisk}": bazelisk_runfile,
+            "{version}": version,
         },
         executable = True,
     )
 
 bazel_binary = repository_rule(
     attrs = {
+        "bazelisk": attr.string(
+            doc = """\
+The label of the bazelisk binary.
+""",
+        ),
         "version": attr.string(
             doc = """\
-The Bazel version to download as a valid Bazel semantic version string.\
+The Bazel version to download as a valid Bazel semantic version string.
 """,
         ),
         "version_file": attr.label(
@@ -196,11 +201,6 @@ The Bazel version to download as a valid Bazel semantic version string.\
             doc = """\
 A file (e.g., `//:.bazelversion`) that contains a valid Bazel semantic version \
 string.\
-""",
-        ),
-        "bazelisk": attr.string(
-            doc = """\
-The label of the bazelisk binary.
 """,
         ),
     },

--- a/bazel_integration_test/private/bazel_binaries_script.template
+++ b/bazel_integration_test/private/bazel_binaries_script.template
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+export USE_BAZEL_VERSION="{version}"
+
+# Need to write data here, the default is read-obly inside tests.
+export BAZELISK_HOME="${PWD}"
+
+# Find the bazelisk binary.
+BINARY="$(rlocation {bazelisk})" || \
+  (echo >&2 "Failed to locate bazelisk at {bazelisk}" && exit 1)
+
+exec "${BINARY}" "$@"

--- a/bazel_integration_test/private/bazel_integration_test.bzl
+++ b/bazel_integration_test/private/bazel_integration_test.bzl
@@ -3,7 +3,6 @@ an integration test.\
 """
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load(":integration_test_utils.bzl", "integration_test_utils")
 
 # This was lovingly inspired by

--- a/bazel_integration_test/private/bazel_integration_test.bzl
+++ b/bazel_integration_test/private/bazel_integration_test.bzl
@@ -49,7 +49,6 @@ def bazel_integration_test(
         additional_env_inherit = [],
         bazel_binaries = None,
         data = None,
-        bazel_basename = "bazel",
         **kwargs):
     """Macro that defines a set of targets for a single Bazel integration test.
 
@@ -97,8 +96,6 @@ def bazel_integration_test(
             `load("@bazel_binaries//:defs.bzl", "bazel_binaries")` to your
             build file.
         data: Optional. A list of files to make present at test runtime.
-        bazel_basename: Optional. The basename of the passed bazel_binaries file.
-                        Defaults to "bazel".
         **kwargs: additional attributes like timeout and visibility
     """
 

--- a/bazel_integration_test/private/bazel_integration_test.bzl
+++ b/bazel_integration_test/private/bazel_integration_test.bzl
@@ -115,27 +115,15 @@ def bazel_integration_test(
     if bazel_binary == None:
         bazel_binary = bazel_binaries.label(bazel_version)
 
-    # Find the Bazel binary
-    bazel_bin_name = name + "_bazel_binary"
-    select_file(
-        name = bazel_bin_name,
-        srcs = bazel_binary,
-        subpath = select({
-            "@platforms//os:windows": bazel_basename + ".exe",
-            "//conditions:default": bazel_basename,
-        }),
-    )
-
     args = [
         "--runner",
         "$(location %s)" % (test_runner),
         "--bazel",
-        "$(location :%s)" % (bazel_bin_name),
+        "$(location %s)" % (bazel_binary),
     ]
     data = (data or []) + [
         test_runner,
         bazel_binary,
-        bazel_bin_name,
     ]
 
     if workspace_files != None and workspace_path == None:


### PR DESCRIPTION
directly.

Fixes #67.