### PR TITLE
chore(deps): upgrade `cgrindel_bazel_starlib` to 0.17.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "rules_python", version = "0.19.0")
 bazel_dep(name = "platforms", version = "0.0.7")
-bazel_dep(name = "cgrindel_bazel_starlib", version = "0.16.0")
+bazel_dep(name = "cgrindel_bazel_starlib", version = "0.17.0")
 
 register_toolchains("@bazel_tools//tools/python:autodetecting_toolchain")
 
@@ -26,5 +26,4 @@ download_sample_file = use_extension(
     "download_sample_file",
     dev_dependency = True,
 )
-
 use_repo(download_sample_file, "sample_file")

--- a/examples/custom_test_runner/MODULE.bazel
+++ b/examples/custom_test_runner/MODULE.bazel
@@ -14,7 +14,7 @@ local_path_override(
 )
 
 bazel_dep(name = "platforms", version = "0.0.7")
-bazel_dep(name = "cgrindel_bazel_starlib", version = "0.15.0")
+bazel_dep(name = "cgrindel_bazel_starlib", version = "0.17.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(
     name = "gazelle",

--- a/examples/simple/MODULE.bazel
+++ b/examples/simple/MODULE.bazel
@@ -3,5 +3,5 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "cgrindel_bazel_starlib", version = "0.14.9")
+bazel_dep(name = "cgrindel_bazel_starlib", version = "0.17.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")


### PR DESCRIPTION
Upgrade `cgrindel_bazel_starlib` to address bug with generating TOC for markdown files.