### PR TITLE
fix: make workspace_file filegroup `testonly`

### DIFF
--- a/bazel_integration_test/private/bazel_integration_test.bzl
+++ b/bazel_integration_test/private/bazel_integration_test.bzl
@@ -135,6 +135,7 @@ def bazel_integration_test(
         native.filegroup(
             name = workspace_files_name,
             srcs = workspace_files,
+            testonly = True,
         )
 
         # Find the Bazel WORKSPACE file for the target workspace. We need to
@@ -145,6 +146,7 @@ def bazel_integration_test(
             name = bazel_wksp_file_name,
             srcs = workspace_files_name,
             workspace_path = workspace_path,
+            testonly = True,
         )
 
         args.extend(["--workspace", "$(location :%s)" % (bazel_wksp_file_name)])


### PR DESCRIPTION
Recreated changes originally in #72 after I messed up the rebase.

Related to #72.
Related to https://github.com/tweag/rules_haskell/pull/1797.

cc: @k1nkreet 