### PR TITLE
feat: return bzlmod extension metadata for declared repositories

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,7 +19,13 @@ bazel_binaries = use_extension(
 )
 bazel_binaries.download(version_file = "//:.bazelversion")
 bazel_binaries.download(version = "6.4.0")
-use_repo(bazel_binaries, "bazel_binaries")
+use_repo(
+    bazel_binaries,
+    "bazel_binaries",
+    "bazel_binaries_bazelisk",
+    "build_bazel_bazel_.bazelversion",
+    "build_bazel_bazel_6_4_0",
+)
 
 download_sample_file = use_extension(
     "//examples/env_var_with_rootpath:sample_file_extension.bzl",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1376,7 +1376,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%bazel_binaries": {
       "general": {
-        "bzlTransitiveDigest": "NvYgoKveJNAsIRLu8JKt9bQJuYTeBnwp13+F9c/rHS4=",
+        "bzlTransitiveDigest": "O7TKulptMidCxRqJMN/xMtga4vaq2sDROGbXAUYiAIQ=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -1418,6 +1418,16 @@
               "current_version": "'@@//:.bazelversion'"
             }
           }
+        },
+        "moduleExtensionMetadata": {
+          "explicitRootModuleDirectDeps": [],
+          "explicitRootModuleDirectDevDeps": [
+            "bazel_binaries_bazelisk",
+            "build_bazel_bazel_.bazelversion",
+            "build_bazel_bazel_6_4_0",
+            "bazel_binaries"
+          ],
+          "useAllRepos": "NO"
         }
       }
     },

--- a/bazel_integration_test/bzlmod/bazel_binaries.bzl
+++ b/bazel_integration_test/bzlmod/bazel_binaries.bzl
@@ -131,12 +131,24 @@ version, version_file.\
 _BAZELISK_VERSION = "1.18.0"
 
 def _bazel_binaries_impl(module_ctx):
+    dep_names = []
+    dev_dep_names = []
+
+    def _add_dep_name(name, is_dev_dependency):
+        if is_dev_dependency:
+            dev_dep_names.append(name)
+        else:
+            dep_names.append(name)
+
+    module_is_dev_dep = not module_ctx.root_module_has_non_dev_dependency
+
     # Create a repository for the bazelisk binary.
     bazelisk_repo_name = "bazel_binaries_bazelisk"
     _bazelisk_binary_repo_rule(
         name = bazelisk_repo_name,
         version = _BAZELISK_VERSION,
     )
+    _add_dep_name(bazelisk_repo_name, is_dev_dependency = module_is_dev_dep)
 
     # Create version-specific bazel repos.
     version_infos = []
@@ -144,6 +156,10 @@ def _bazel_binaries_impl(module_ctx):
         for download in mod.tags.download:
             vi = _declare_bazel_binary(download, bazelisk_repo_name)
             version_infos.append(vi)
+            _add_dep_name(
+                vi.repo_name,
+                is_dev_dependency = module_ctx.is_dev_dependency(download),
+            )
 
     if len(version_infos) == 0:
         fail("No versions were specified.")
@@ -158,10 +174,17 @@ def _bazel_binaries_impl(module_ctx):
         if current_vi == None:
             current_vi = version_infos[0]
 
+    bazel_binaries_repo_name = "bazel_binaries"
     _bazel_binaries_helper(
-        name = "bazel_binaries",
+        name = bazel_binaries_repo_name,
         version_to_repo = version_to_repo,
         current_version = current_vi.version,
+    )
+    _add_dep_name(bazel_binaries_repo_name, is_dev_dependency = module_is_dev_dep)
+
+    return module_ctx.extension_metadata(
+        root_module_direct_deps = dep_names,
+        root_module_direct_dev_deps = dev_dep_names,
     )
 
 _download_tag = tag_class(

--- a/bazel_integration_test/bzlmod/bazel_binaries.bzl
+++ b/bazel_integration_test/bzlmod/bazel_binaries.bzl
@@ -140,7 +140,7 @@ def _bazel_binaries_impl(module_ctx):
         else:
             dep_names.append(name)
 
-    module_is_dev_dep = not module_ctx.root_module_has_non_dev_dependency
+    ext_is_dev_dep = not module_ctx.root_module_has_non_dev_dependency
 
     # Create a repository for the bazelisk binary.
     bazelisk_repo_name = "bazel_binaries_bazelisk"
@@ -148,7 +148,7 @@ def _bazel_binaries_impl(module_ctx):
         name = bazelisk_repo_name,
         version = _BAZELISK_VERSION,
     )
-    _add_dep_name(bazelisk_repo_name, is_dev_dependency = module_is_dev_dep)
+    _add_dep_name(bazelisk_repo_name, is_dev_dependency = ext_is_dev_dep)
 
     # Create version-specific bazel repos.
     version_infos = []
@@ -180,7 +180,7 @@ def _bazel_binaries_impl(module_ctx):
         version_to_repo = version_to_repo,
         current_version = current_vi.version,
     )
-    _add_dep_name(bazel_binaries_repo_name, is_dev_dependency = module_is_dev_dep)
+    _add_dep_name(bazel_binaries_repo_name, is_dev_dependency = ext_is_dev_dep)
 
     return module_ctx.extension_metadata(
         root_module_direct_deps = dep_names,

--- a/examples/custom_test_runner/MODULE.bazel
+++ b/examples/custom_test_runner/MODULE.bazel
@@ -34,7 +34,12 @@ bazel_binaries = use_extension(
     dev_dependency = True,
 )
 bazel_binaries.download(version_file = "//:.bazelversion")
-use_repo(bazel_binaries, "bazel_binaries")
+use_repo(
+    bazel_binaries,
+    "bazel_binaries",
+    "bazel_binaries_bazelisk",
+    "build_bazel_bazel_.bazelversion",
+)
 
 # swift_deps START
 swift_deps = use_extension(


### PR DESCRIPTION
- Update `bazel_binaries` extension to return metadata listing the declared repositories.
- Update `custom_test_runner` test to properly declare its repositories.

Closes #235.