### PR TITLE
feat: support local Bazel binaries using `bazel_binaries.local()`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,11 +19,7 @@ bazel_binaries = use_extension(
 )
 bazel_binaries.download(version_file = "//:.bazelversion")
 bazel_binaries.download(version = "6.4.0")
-
-# DEBUG BEGIN
-bazel_binaries.local(path = "/Users/chuck/tmp/bazel.sh")
-
-# DEBUG END
+bazel_binaries.local(path = "tools/fake_bazel.sh")
 use_repo(
     bazel_binaries,
     "bazel_binaries",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,12 +19,18 @@ bazel_binaries = use_extension(
 )
 bazel_binaries.download(version_file = "//:.bazelversion")
 bazel_binaries.download(version = "6.4.0")
+
+# DEBUG BEGIN
+bazel_binaries.local(path = "/Users/chuck/tmp/bazel.sh")
+
+# DEBUG END
 use_repo(
     bazel_binaries,
     "bazel_binaries",
     "bazel_binaries_bazelisk",
     "build_bazel_bazel_.bazelversion",
     "build_bazel_bazel_6_4_0",
+    "build_bazel_bazel_local",
 )
 
 download_sample_file = use_extension(

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1396,7 +1396,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%bazel_binaries": {
       "general": {
-        "bzlTransitiveDigest": "J/kSRokYnmVjMYHkLb/K4e6GmXrixe32sMCCRSW9fDw=",
+        "bzlTransitiveDigest": "SrboP1DtxYyLiTGjudFCeiwGebgp5hldobw6UXIEPPs=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "60ab976a6ba7a3784ee15ae4b3a93a089a0d40c779860bd9afc3ad609e69ce27",
+  "moduleFileHash": "8771944058783db67d1dba89bf1f8d780495fbd54fbb27f84601619337670204",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -77,12 +77,12 @@
             {
               "tagName": "local",
               "attributeValues": {
-                "path": "/Users/chuck/tmp/bazel.sh"
+                "path": "tools/fake_bazel.sh"
               },
               "devDependency": true,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 24,
+                "line": 22,
                 "column": 21
               }
             }
@@ -96,7 +96,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 36,
+            "line": 32,
             "column": 37
           },
           "imports": {
@@ -1396,7 +1396,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%bazel_binaries": {
       "general": {
-        "bzlTransitiveDigest": "SrboP1DtxYyLiTGjudFCeiwGebgp5hldobw6UXIEPPs=",
+        "bzlTransitiveDigest": "2YpQtmxm7IW8Ldz4jpGThmEDybtrPhL/NCQeG1JSpPI=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -1414,7 +1414,7 @@
             "ruleClassName": "local_bazel_binary",
             "attributes": {
               "name": "_main~bazel_binaries~build_bazel_bazel_local",
-              "path": "/Users/chuck/tmp/bazel.sh"
+              "path": "tools/fake_bazel.sh"
             }
           },
           "bazel_binaries_bazelisk": {

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "2468fff26477f2fa8eaf55fbe9fc68b3ebcfe2823c502de84395aae37f3d00e9",
+  "moduleFileHash": "60ab976a6ba7a3784ee15ae4b3a93a089a0d40c779860bd9afc3ad609e69ce27",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -39,13 +39,15 @@
             "bazel_binaries": "bazel_binaries",
             "bazel_binaries_bazelisk": "bazel_binaries_bazelisk",
             "build_bazel_bazel_.bazelversion": "build_bazel_bazel_.bazelversion",
-            "build_bazel_bazel_6_4_0": "build_bazel_bazel_6_4_0"
+            "build_bazel_bazel_6_4_0": "build_bazel_bazel_6_4_0",
+            "build_bazel_bazel_local": "build_bazel_bazel_local"
           },
           "devImports": [
             "bazel_binaries",
             "bazel_binaries_bazelisk",
             "build_bazel_bazel_.bazelversion",
-            "build_bazel_bazel_6_4_0"
+            "build_bazel_bazel_6_4_0",
+            "build_bazel_bazel_local"
           ],
           "tags": [
             {
@@ -71,6 +73,18 @@
                 "line": 21,
                 "column": 24
               }
+            },
+            {
+              "tagName": "local",
+              "attributeValues": {
+                "path": "/Users/chuck/tmp/bazel.sh"
+              },
+              "devDependency": true,
+              "location": {
+                "file": "@@//:MODULE.bazel",
+                "line": 24,
+                "column": 21
+              }
             }
           ],
           "hasDevUseExtension": true,
@@ -82,7 +96,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 30,
+            "line": 36,
             "column": 37
           },
           "imports": {
@@ -1382,7 +1396,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%bazel_binaries": {
       "general": {
-        "bzlTransitiveDigest": "djw3UcvEzTXoLZpPG72izgEbS8EAa3FuWL2OgSoQObM=",
+        "bzlTransitiveDigest": "J/kSRokYnmVjMYHkLb/K4e6GmXrixe32sMCCRSW9fDw=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -1393,6 +1407,14 @@
               "name": "_main~bazel_binaries~build_bazel_bazel_6_4_0",
               "version": "6.4.0",
               "bazelisk": "@bazel_binaries_bazelisk//:bazelisk"
+            }
+          },
+          "build_bazel_bazel_local": {
+            "bzlFile": "@@//bazel_integration_test/private:bazel_binaries.bzl",
+            "ruleClassName": "local_bazel_binary",
+            "attributes": {
+              "name": "_main~bazel_binaries~build_bazel_bazel_local",
+              "path": "/Users/chuck/tmp/bazel.sh"
             }
           },
           "bazel_binaries_bazelisk": {
@@ -1419,7 +1441,8 @@
               "name": "_main~bazel_binaries~bazel_binaries",
               "version_to_repo": {
                 "'@@//:.bazelversion'": "build_bazel_bazel_.bazelversion",
-                "6.4.0": "build_bazel_bazel_6_4_0"
+                "6.4.0": "build_bazel_bazel_6_4_0",
+                "local": "build_bazel_bazel_local"
               },
               "current_version": "'@@//:.bazelversion'"
             }
@@ -1431,6 +1454,7 @@
             "bazel_binaries_bazelisk",
             "build_bazel_bazel_.bazelversion",
             "build_bazel_bazel_6_4_0",
+            "build_bazel_bazel_local",
             "bazel_binaries"
           ],
           "useAllRepos": "NO"

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "b539be22aff628947231a866038b521ff6ecd95547aba830ceb3abbca711fd6a",
+  "moduleFileHash": "2468fff26477f2fa8eaf55fbe9fc68b3ebcfe2823c502de84395aae37f3d00e9",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -36,10 +36,16 @@
             "column": 31
           },
           "imports": {
-            "bazel_binaries": "bazel_binaries"
+            "bazel_binaries": "bazel_binaries",
+            "bazel_binaries_bazelisk": "bazel_binaries_bazelisk",
+            "build_bazel_bazel_.bazelversion": "build_bazel_bazel_.bazelversion",
+            "build_bazel_bazel_6_4_0": "build_bazel_bazel_6_4_0"
           },
           "devImports": [
-            "bazel_binaries"
+            "bazel_binaries",
+            "bazel_binaries_bazelisk",
+            "build_bazel_bazel_.bazelversion",
+            "build_bazel_bazel_6_4_0"
           ],
           "tags": [
             {
@@ -76,7 +82,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 24,
+            "line": 30,
             "column": 37
           },
           "imports": {
@@ -1376,7 +1382,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%bazel_binaries": {
       "general": {
-        "bzlTransitiveDigest": "O7TKulptMidCxRqJMN/xMtga4vaq2sDROGbXAUYiAIQ=",
+        "bzlTransitiveDigest": "djw3UcvEzTXoLZpPG72izgEbS8EAa3FuWL2OgSoQObM=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/bazel_integration_test/bzlmod/bazel_binaries.bzl
+++ b/bazel_integration_test/bzlmod/bazel_binaries.bzl
@@ -5,6 +5,7 @@ load(
     "//bazel_integration_test/private:bazel_binaries.bzl",
     _bazel_binary_repo_rule = "bazel_binary",
     _bazelisk_binary_repo_rule = "bazelisk_binary",
+    _local_bazel_binary_repo_rule = "local_bazel_binary",
 )
 load("//bazel_integration_test/private:no_deps_utils.bzl", "no_deps_utils")
 
@@ -95,6 +96,7 @@ def _version_info(version, type, current):
 _version_types = struct(
     string = "string",
     label = "label",
+    local = "local",
 )
 
 def _declare_bazel_binary(download, bazelisk_repo_name):
@@ -125,6 +127,18 @@ version, version_file.\
             version_file = download.version_file,
             bazelisk = "@%s//:bazelisk" % bazelisk_repo_name,
         )
+    return vi
+
+def _declare_local_bazel_binary(local):
+    vi = _version_info(
+        version = local.name,
+        type = _version_types.local,
+        current = local.current,
+    )
+    _local_bazel_binary_repo_rule(
+        name = vi.repo_name,
+        path = local.path,
+    )
     return vi
 
 # TODO(GH184): Make this configurable.
@@ -159,6 +173,13 @@ def _bazel_binaries_impl(module_ctx):
             _add_dep_name(
                 vi.repo_name,
                 is_dev_dependency = module_ctx.is_dev_dependency(download),
+            )
+        for local in mod.tags.local:
+            vi = _declare_local_bazel_binary(local)
+            version_infos.append(vi)
+            _add_dep_name(
+                vi.repo_name,
+                is_dev_dependency = module_ctx.is_dev_dependency(local),
             )
 
     if len(version_infos) == 0:
@@ -211,9 +232,23 @@ Identifies Bazel versions that will be downloaded and made available for \
 """,
 )
 
+_local_tag = tag_class(
+    attrs = {
+        "current": attr.bool(
+            doc = "Designate this version as the current version.",
+        ),
+        "name": attr.string(
+            default = "local",
+        ),
+        "path": attr.label(
+            allow_single_file = True,
+        ),
+    },
+)
+
 bazel_binaries = module_extension(
     implementation = _bazel_binaries_impl,
-    tag_classes = {"download": _download_tag},
+    tag_classes = {"download": _download_tag, "local": _local_tag},
     doc = """\
 Provides a means for clients to download Bazel binaries for their integration \
 tests.\

--- a/bazel_integration_test/bzlmod/bazel_binaries.bzl
+++ b/bazel_integration_test/bzlmod/bazel_binaries.bzl
@@ -135,11 +135,6 @@ def _declare_local_bazel_binary(local):
         type = _version_types.local,
         current = local.current,
     )
-
-    # DEBUG BEGIN
-    print("*** CHUCK vi: ", vi)
-
-    # DEBUG END
     _local_bazel_binary_repo_rule(
         name = vi.repo_name,
         path = local.path,
@@ -244,14 +239,19 @@ _local_tag = tag_class(
         ),
         "name": attr.string(
             default = "local",
+            doc = """\
+This value is used to generate a repository name from which the local Bazel \
+binary is referenced.\
+""",
         ),
         "path": attr.string(
             mandatory = True,
+            doc = "The path to the Bazel binary.",
         ),
-        # "path": attr.label(
-        #     allow_single_file = True,
-        # ),
     },
+    doc = """\
+Makes a local Bazel binary available for use in an integration test.\
+""",
 )
 
 bazel_binaries = module_extension(

--- a/bazel_integration_test/bzlmod/bazel_binaries.bzl
+++ b/bazel_integration_test/bzlmod/bazel_binaries.bzl
@@ -135,6 +135,11 @@ def _declare_local_bazel_binary(local):
         type = _version_types.local,
         current = local.current,
     )
+
+    # DEBUG BEGIN
+    print("*** CHUCK vi: ", vi)
+
+    # DEBUG END
     _local_bazel_binary_repo_rule(
         name = vi.repo_name,
         path = local.path,
@@ -240,9 +245,12 @@ _local_tag = tag_class(
         "name": attr.string(
             default = "local",
         ),
-        "path": attr.label(
-            allow_single_file = True,
+        "path": attr.string(
+            mandatory = True,
         ),
+        # "path": attr.label(
+        #     allow_single_file = True,
+        # ),
     },
 )
 

--- a/bazel_integration_test/private/BUILD.bazel
+++ b/bazel_integration_test/private/BUILD.bazel
@@ -49,6 +49,7 @@ bzl_library(
     srcs = ["bazel_binaries.bzl"],
     deps = [
         ":no_deps_utils",
+        "@bazel_skylib//lib:paths",
         "@cgrindel_bazel_starlib//bzllib:defs",
     ],
 )

--- a/bazel_integration_test/private/bazel_binaries.bzl
+++ b/bazel_integration_test/private/bazel_binaries.bzl
@@ -170,26 +170,33 @@ Download a bazel binary for integration test.\
 # MARK: - local_bazel_binary Repository Rule
 
 def _local_bazel_binary_impl(repository_ctx):
-    repository_ctx.symlink(
-        target = repository_ctx.attr.path,
-        link_name = "bazel",
-    )
+    repository_ctx.symlink(repository_ctx.attr.path, "bazel")
     repository_ctx.file("WORKSPACE", "workspace(name='%s')" % repository_ctx.attr.name)
     repository_ctx.file("BUILD", """
 exports_files(
     ["bazel"],
     visibility = ["//visibility:public"],
-)""")
+)
 
-local_bazel_binary = rule(
+alias(
+    name = "bazel_binary",
+    actual = "bazel",
+    visibility = ["//visibility:public"],
+)
+""")
+
+local_bazel_binary = repository_rule(
     implementation = _local_bazel_binary_impl,
     attrs = {
-        "path": attr.label(
-            allow_single_file = True,
+        "path": attr.string(
             mandatory = True,
-            executable = True,
-            cfg = "exec",
         ),
+        # "path": attr.label(
+        #     allow_single_file = True,
+        #     mandatory = True,
+        #     executable = True,
+        #     cfg = "exec",
+        # ),
     },
     doc = "",
 )

--- a/bazel_integration_test/private/bazel_binaries.bzl
+++ b/bazel_integration_test/private/bazel_binaries.bzl
@@ -1,5 +1,6 @@
 """Manages the download of Bazel binaries."""
 
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@cgrindel_bazel_starlib//bzllib:defs.bzl", "lists")
 load(":no_deps_utils.bzl", "no_deps_utils")
 
@@ -170,7 +171,11 @@ Download a bazel binary for integration test.\
 # MARK: - local_bazel_binary Repository Rule
 
 def _local_bazel_binary_impl(repository_ctx):
-    repository_ctx.symlink(repository_ctx.attr.path, "bazel")
+    path = repository_ctx.attr.path
+    if not paths.is_absolute(path):
+        path = paths.join(str(repository_ctx.workspace_root), path)
+
+    repository_ctx.symlink(path, "bazel")
     repository_ctx.file("WORKSPACE", "workspace(name='%s')" % repository_ctx.attr.name)
     repository_ctx.file("BUILD", """
 exports_files(

--- a/bazel_integration_test/private/bazel_binaries.bzl
+++ b/bazel_integration_test/private/bazel_binaries.bzl
@@ -167,6 +167,33 @@ Download a bazel binary for integration test.\
 """,
 )
 
+# MARK: - local_bazel_binary Repository Rule
+
+def _local_bazel_binary_impl(repository_ctx):
+    repository_ctx.symlink(
+        target = repository_ctx.attr.path,
+        link_name = "bazel",
+    )
+    repository_ctx.file("WORKSPACE", "workspace(name='%s')" % repository_ctx.attr.name)
+    repository_ctx.file("BUILD", """
+exports_files(
+    ["bazel"],
+    visibility = ["//visibility:public"],
+)""")
+
+local_bazel_binary = rule(
+    implementation = _local_bazel_binary_impl,
+    attrs = {
+        "path": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    doc = "",
+)
+
 # MARK: - bazel_binaries_helper Repository Rule
 
 _BAZEL_BINARIES_HELPER_DEFS_BZL = """\

--- a/bazel_integration_test/private/bazel_binaries.bzl
+++ b/bazel_integration_test/private/bazel_binaries.bzl
@@ -190,15 +190,12 @@ local_bazel_binary = repository_rule(
     attrs = {
         "path": attr.string(
             mandatory = True,
+            doc = "The path to a Bazel binary.",
         ),
-        # "path": attr.label(
-        #     allow_single_file = True,
-        #     mandatory = True,
-        #     executable = True,
-        #     cfg = "exec",
-        # ),
     },
-    doc = "",
+    doc = """\
+Makes a local Bazel binary available for use in an integration test.\
+""",
 )
 
 # MARK: - bazel_binaries_helper Repository Rule

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -11,6 +11,8 @@ load(
 
 bzlformat_pkg(name = "bzlformat")
 
+_LOCAL_BAZEL_BINARY_VERSION = "local"
+
 # MARK: - Simple Tests
 
 default_test_runner(
@@ -56,6 +58,12 @@ bazel_integration_test(
     workspace_path = "simple",
 )
 
+_SIMPLE_TEST_VERSIONS = [
+    version
+    for version in bazel_binaries.versions.other
+    if version != _LOCAL_BAZEL_BINARY_VERSION
+]
+
 # If you want to execute an integration test using multiple versions of Bazel,
 # use bazel_integration_tests. It will generate multiple integration test
 # targets with names derived from the base name and the bazel version.
@@ -63,7 +71,7 @@ bazel_integration_tests(
     # buildifier: disable=duplicated-name
     name = "simple_test",
     bazel_binaries = bazel_binaries,
-    bazel_versions = bazel_binaries.versions.other,
+    bazel_versions = _SIMPLE_TEST_VERSIONS,
     test_runner = ":simple_test_runner",
     workspace_files = integration_test_utils.glob_workspace_files("simple") + [
         "//:shared_bazelrc_files",
@@ -159,6 +167,19 @@ script_test(
     ],
 )
 
+# MARK: - Local Bazel Binary Example/Test
+
+script_test(
+    name = "local_bazel_binary_test",
+    srcs = ["local_bazel_binary_test.sh"],
+    bazel_binaries = bazel_binaries,
+    bazel_version = _LOCAL_BAZEL_BINARY_VERSION,
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_starlib//shlib/lib:assertions",
+    ],
+)
+
 # MARK: - Test Suite
 
 # By default, the integration test targets are tagged as `manual`. This
@@ -179,7 +200,7 @@ test_suite(
         ":use_create_scratch_dir_test",
     ] + integration_test_utils.bazel_integration_test_names(
         "simple_test",
-        bazel_binaries.versions.other,
+        _SIMPLE_TEST_VERSIONS,
     ),
     visibility = ["//:__subpackages__"],
 )

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -195,6 +195,7 @@ test_suite(
         ":custom_test_runner_test",
         ":dynamic_workspace_test",
         ":legacy_simple_test",
+        ":local_bazel_binary_test",
         ":sample_script_test",
         ":simple_test",
         ":use_create_scratch_dir_test",

--- a/examples/local_bazel_binary_test.sh
+++ b/examples/local_bazel_binary_test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -o nounset -o pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -o errexit
+# --- end runfiles.bash initialization v2 ---
+
+# MARK - Locate Deps
+
+assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
+assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+source "${assertions_sh}"
+
+# MARK - Test
+
+# Verify the fake bazel binary is called.
+${BIT_BAZEL_BINARY} info release 
+${BIT_BAZEL_BINARY} test //...
+
+output_file="fake_bazel.out"
+[[ -e "$output_file" ]] || fail "Did not find output file."
+
+actual="$(<"${output_file}")"
+expected="$(cat <<-EOF
+Fake Bazel Script: info release
+Fake Bazel Script: test //...
+EOF
+)"
+
+assert_equal "${expected}" "${actual}" "check expected output"

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 
+exports_files(["fake_bazel.sh"])
+
 bzlformat_pkg(name = "bzlformat")
 
 filegroup(

--- a/tools/fake_bazel.sh
+++ b/tools/fake_bazel.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# This executable script acts as a stand-in for a Bazel binary to test 
+# `bazel_binaries.local()`. 
+
+set -o errexit -o nounset -o pipefail
+
+echo "Fake Bazel Script:" "$@" | tee -a "fake_bazel.out"


### PR DESCRIPTION
Allow a client to execute Bazel integration tests using a local Bazel binary.

```python
bazel_binaries = use_extension(
    "//:extensions.bzl",
    "bazel_binaries",
    dev_dependency = True,
)
bazel_binaries.download(version_file = "//:.bazelversion")
bazel_binaries.download(version = "6.4.0")
bazel_binaries.local(path = "/path/to/bazel", name = "foo"). # <=== An absolute or relative path to a Bazel binary.
use_repo(
    bazel_binaries,
    "bazel_binaries",
    # ...
    "build_bazel_bazel_foo",   # <=== The repository name for the local Bazel binary.
)
```

Then, you can use the Bazel binary in integration tests by using the `name` value as the `version`.

```python
script_test(
    name = "local_bazel_binary_test",
    srcs = ["local_bazel_binary_test.sh"],
    bazel_binaries = bazel_binaries,
    bazel_version = "foo",  # <=== The version is the name specified above.
    deps = [
        "@bazel_tools//tools/bash/runfiles",
        "@cgrindel_bazel_starlib//shlib/lib:assertions",
    ],
)
```