### PR TITLE
chore: test after accidental push to `main` upgrading Bazel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Ignore Bazel symlinks
 bazel-*
 
+


### PR DESCRIPTION
I accidentally pushed [a commit](https://github.com/bazel-contrib/rules_bazel_integration_test/commit/ac76fcf525b778f4ad808b4bc3594b55fcb2d35a) to `main` that upgrades Bazel to 7.0.0rc3. I created this PR to run CI to ensure that all is well.