### PR TITLE
fix: do not fail if no results using GNU `xargs`

### DIFF
--- a/tests/tools_tests/find_child_workspace_packages_test.sh
+++ b/tests/tools_tests/find_child_workspace_packages_test.sh
@@ -22,8 +22,12 @@ initial_test_dir="${PWD}"
 
 # MARK - Execute without a workspace
 
-"${find_bin}" --workspace "${PWD}" \
-  || fail "Expected no failure with no child workspace."
+actual=()
+while IFS=$'\n' read -r line; do actual+=("$line"); done < <(
+  "${find_bin}" --workspace "${PWD}" \
+    || fail "Expected no failure with no child workspace."
+)
+assert_equal 0 "${#actual[@]}" "no child workspace"
 
 # MARK - Execute with empty workspace
 
@@ -31,8 +35,12 @@ empty_example_workspace_dir="${PWD}/examples/empty"
 mkdir -p "${empty_example_workspace_dir}"
 touch "${empty_example_workspace_dir}/WORKSPACE"
 
-"${find_bin}" --workspace "${PWD}" \
-  || fail "Expected no failure with empty child workspace."
+actual=()
+while IFS=$'\n' read -r line; do actual+=("$line"); done < <(
+  "${find_bin}" --workspace "${PWD}" \
+    || fail "Expected no failure with empty child workspace."
+)
+assert_equal 0 "${#actual[@]}" "empty child workspace"
 
 rm -rf "${empty_example_workspace_dir}"
 

--- a/tools/find_child_workspace_packages.sh
+++ b/tools/find_child_workspace_packages.sh
@@ -43,10 +43,22 @@ source "${shared_fns_sh}"
 
 find_bazel_pkgs() {
   local path="${1}"
+
+  # # DEBUG BEGIN
+  # dbg_output="$( find "${path}" \( -name BUILD -or -name BUILD.bazel \) -print0 )"
+  # echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") dbg_output: ${dbg_output}" 
+  # # DEBUG END
+
   # Make sure that the -print0 is the last primary for find. Otherwise, you
   # will get undesirable results.
   while IFS=$'\n' read -r line; do filter_bazelignored_directories "${path}" "${line}" ; done < <(
-    find "${path}" \( -name BUILD -or -name BUILD.bazel \) -print0 | xargs -0 -n 1 dirname 
+    # The -r in the xargs tells gnu xargs not to run if empty. The FreeBSD 
+    # version supports the flag, but ignores it as it provides this behavior
+    # by default.
+    # The -S 511 addresses "xargs: command line cannot be assembled, too long" 
+    # errors that can occur if the found paths are long.
+    find "${path}" \( -name BUILD -or -name BUILD.bazel \) -print0 | \
+      xargs -r -0 -S 511 -I {} dirname "{}"
   )
 }
 

--- a/tools/find_child_workspace_packages.sh
+++ b/tools/find_child_workspace_packages.sh
@@ -44,14 +44,11 @@ source "${shared_fns_sh}"
 find_bazel_pkgs() {
   local path="${1}"
 
-  # # DEBUG BEGIN
-  # dbg_output="$( find "${path}" \( -name BUILD -or -name BUILD.bazel \) -print0 )"
-  # echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") dbg_output: ${dbg_output}" 
-  # # DEBUG END
-
   # Make sure that the -print0 is the last primary for find. Otherwise, you
   # will get undesirable results.
   while IFS=$'\n' read -r line; do filter_bazelignored_directories "${path}" "${line}" ; done < <(
+    # NOTE: If you update the find or xargs flags, be sure to check if those 
+    # changes should be applied to find_workspace_dirs in shared_fns.sh.
     # The -r in the xargs tells gnu xargs not to run if empty. The FreeBSD 
     # version supports the flag, but ignores it as it provides this behavior
     # by default.

--- a/tools/find_child_workspace_packages.sh
+++ b/tools/find_child_workspace_packages.sh
@@ -49,13 +49,8 @@ find_bazel_pkgs() {
   while IFS=$'\n' read -r line; do filter_bazelignored_directories "${path}" "${line}" ; done < <(
     # NOTE: If you update the find or xargs flags, be sure to check if those 
     # changes should be applied to find_workspace_dirs in shared_fns.sh.
-    # The -r in the xargs tells gnu xargs not to run if empty. The FreeBSD 
-    # version supports the flag, but ignores it as it provides this behavior
-    # by default.
-    # The -S 511 addresses "xargs: command line cannot be assembled, too long" 
-    # errors that can occur if the found paths are long.
     find "${path}" \( -name BUILD -or -name BUILD.bazel \) -print0 | \
-      xargs -r -0 -S 511 -I {} dirname "{}"
+      exec_cmd_for_each dirname "{}"
   )
 }
 

--- a/tools/shared_fns.sh
+++ b/tools/shared_fns.sh
@@ -36,6 +36,12 @@ find_workspace_dirs() {
   # Make sure that the -print0 is the last primary for find. Otherwise, you
   # will get undesirable results.
   while IFS=$'\n' read -r line; do filter_bazelignored_directories "${path}" "${line}" ; done < <(
-    find "${path}" \( -name "WORKSPACE" -o -name "WORKSPACE.bazel" \) -print0  | xargs -0 -n 1 dirname
+    # The -r in the xargs tells gnu xargs not to run if empty. The FreeBSD 
+    # version supports the flag, but ignores it as it provides this behavior
+    # by default.
+    # The -S 511 addresses "xargs: command line cannot be assembled, too long" 
+    # errors that can occur if the found paths are long.
+    find "${path}" \( -name "WORKSPACE" -o -name "WORKSPACE.bazel" \) -print0  | \
+      xargs -r -S 511 -0 -I {} dirname "{}"
   )
 }

--- a/tools/shared_fns.sh
+++ b/tools/shared_fns.sh
@@ -36,6 +36,8 @@ find_workspace_dirs() {
   # Make sure that the -print0 is the last primary for find. Otherwise, you
   # will get undesirable results.
   while IFS=$'\n' read -r line; do filter_bazelignored_directories "${path}" "${line}" ; done < <(
+    # NOTE: If you update the find or xargs flags, be sure to check if those 
+    # changes should be applied to find_bazel_pkgs in find_child_workspace_packages.sh.
     # The -r in the xargs tells gnu xargs not to run if empty. The FreeBSD 
     # version supports the flag, but ignores it as it provides this behavior
     # by default.


### PR DESCRIPTION
- Added `-r` flag to `xargs` to ensure that the specified command does not run if there are no results in stdin.
- Use `-I {}` with `xargs` to be cross-platform compatible. This ensures that the command will execute for each result.
- Add `-S 511` to `xargs` to ensure that `xargs` does not fail with `xargs: command line cannot be assembled, too long` if the paths are very long. The default command length for `xargs` is 255. 
- Beefed up the unit tests for `find_child_workspace_packages`.

Closes #189.