### PR TITLE
fix: add Bazel version to BCR presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,9 +2,13 @@ bcr_test_module:
   module_path: ""
   matrix:
     platform: ["macos", "ubuntu2004"]
+    bazel:
+      # This needs to exactly match the value used in .bazelversion at the root.
+      - 7.1.2
   tasks:
     run_tests:
       name: "Run test module"
       platform: ${{ platform }}
+      bazel: ${{ bazel }}
       test_targets:
         - "//bazel_integration_test/bzlmod/..."


### PR DESCRIPTION
BCR requires the Bazel version.
