### PR TITLE
chore: sync the BCR presubmit Bazel version with .bazelversion

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     platform: ["macos", "ubuntu2004"]
     bazel:
       # This needs to exactly match the value used in .bazelversion at the root.
-      - 7.1.2
+      - 7.3.2
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
These values need to be the same.
