### PR TITLE
fix: upgrade to macos-14 GitHub runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  XCODE_VERSION: 14.0.1
+  XCODE_VERSION: 16.1.0
 
 jobs:
   tidy_and_test_matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [macos-12, ubuntu-22.04]
+        runner: [macos-14, ubuntu-22.04]
     runs-on: ${{ matrix.runner }}
     env:
       # Linux runners need this.
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [macos-12, ubuntu-22.04]
+        runner: [macos-14, ubuntu-22.04]
     runs-on: ${{ matrix.runner }}
     env:
       # Linux runners need this.


### PR DESCRIPTION
Apparently, we were still using `macos-12`, which is now [deprecated](https://github.com/bazel-contrib/rules_bazel_integration_test/actions/runs/11665997473?pr=383). 
