### PR TITLE
fix: upgrade to macos-15 runners to avoid missing Xcode error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [macos-14, ubuntu-22.04]
+        runner: [macos-15, ubuntu-22.04]
     runs-on: ${{ matrix.runner }}
     env:
       # Linux runners need this.
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [macos-14, ubuntu-22.04]
+        runner: [macos-15, ubuntu-22.04]
     runs-on: ${{ matrix.runner }}
     env:
       # Linux runners need this.


### PR DESCRIPTION
Apparently, Xcode 16 was removed from `macos-14` back in October. I am not sure why it is just failing now.

Related to https://github.com/actions/runner-images/issues/10703.
