### PR TITLE
fix: hidden files being copied to the wrong directory

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -145,6 +145,7 @@ sh_binary(
     ],
     deps = [
         "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_starlib//shlib/lib:arrays",
         "@cgrindel_bazel_starlib//shlib/lib:assertions",
     ],
 )

--- a/examples/simple/BUILD.bazel
+++ b/examples/simple/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
     "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
@@ -18,4 +19,11 @@ genrule(
     srcs = [".hidden_file"],
     outs = ["copy_of_hidden_file"],
     cmd = "cat $(location .hidden_file) > $@",
+)
+
+build_test(
+    name = "copy_hidden_file_test",
+    targets = [
+        ":copy_hidden_file",
+    ],
 )

--- a/examples/simple/mockascript/private/.another_hidden_file
+++ b/examples/simple/mockascript/private/.another_hidden_file
@@ -1,0 +1,1 @@
+# Used to test hidden file copy in a sub-directory

--- a/examples/simple/mockascript/private/BUILD.bazel
+++ b/examples/simple/mockascript/private/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//mockascript:__subpackages__"])
@@ -9,3 +10,18 @@ bzl_library(
 )
 
 bzlformat_pkg()
+
+# This exists to ensure that the hidden file is copied by create_scratch_dir.sh
+genrule(
+    name = "copy_hidden_file",
+    srcs = [".another_hidden_file"],
+    outs = ["copy_of_hidden_file"],
+    cmd = "cat $(location .another_hidden_file) > $@",
+)
+
+build_test(
+    name = "copy_hidden_file_test",
+    targets = [
+        ":copy_hidden_file",
+    ],
+)

--- a/tools/create_scratch_dir.sh
+++ b/tools/create_scratch_dir.sh
@@ -67,8 +67,8 @@ cd "${workspace_dir}"
 # Copy the non-hidden files
 cp -R -L ./* "${scratch_dir}"
 
-# Copy the hidden files
-find . \( -type f -or -type l \) -name ".*" -print0 | xargs -0 -I {} cp -f {} "${scratch_dir}/"
+# # Copy the hidden files
+# find . \( -type f -or -type l \) -name ".*" -print0 | xargs -0 -I {} cp {} "${scratch_dir}/"
 
 # Output the scratch directory
 echo "${scratch_dir}"

--- a/tools/create_scratch_dir.sh
+++ b/tools/create_scratch_dir.sh
@@ -64,11 +64,11 @@ mkdir -p "${scratch_dir}"
 # Change to the workspace dir
 cd "${workspace_dir}"
 
-# Copy the non-hidden files
+# Copy the files. All but the top-level hidden files will be copied.
 cp -R -L ./* "${scratch_dir}"
 
-# # Copy the hidden files
-# find . \( -type f -or -type l \) -name ".*" -print0 | xargs -0 -I {} cp {} "${scratch_dir}/"
+# Copy the top-level, hidden files.
+find . -maxdepth 1 \( -type f -or -type l \) -name ".*" -print0 | xargs -0 -I {} cp {} "${scratch_dir}/"
 
 # Output the scratch directory
 echo "${scratch_dir}"

--- a/tools/create_scratch_dir.sh
+++ b/tools/create_scratch_dir.sh
@@ -65,10 +65,10 @@ mkdir -p "${scratch_dir}"
 cd "${workspace_dir}"
 
 # Copy the non-hidden files
-cp -R -L * "${scratch_dir}"
+cp -R -L ./* "${scratch_dir}"
 
 # Copy the hidden files
-find . \( -type f -or -type l \) -name ".*" -print0 | xargs -0 -I {} cp {} "${scratch_dir}/"
+find . \( -type f -or -type l \) -name ".*" -print0 | xargs -0 -I {} cp -f {} "${scratch_dir}/"
 
 # Output the scratch directory
 echo "${scratch_dir}"


### PR DESCRIPTION
The initial copy will copy over hidden files in sub-directories. The copy `find` logic for hidden files was looking through the entire tree. We really just want to copy the hidden files in the top-level directory.

Also, adjusted the glob pattern for the "non-hidden" file copy per a shellcheck warning.