### PR TITLE
Add explicit `--enable_workspace` so that this test works with Bazel 8

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -22,6 +22,7 @@ default_test_runner(
 
 _LEGACY_FLAGS = [
     "--noenable_bzlmod",
+    "--enable_workspace",
     "--no@cgrindel_bazel_starlib//bzlmod:enabled",
 ]
 


### PR DESCRIPTION
This fixes the failing test from #410.
