### PR TITLE
fix: add sh_library loads for bazel 8.x support

### DIFF
--- a/tests/tools_tests/BUILD.bazel
+++ b/tests/tools_tests/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("@rules_shell//shell:sh_library.bzl", "sh_library")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("@rules_shell//shell:sh_library.bzl", "sh_library")
 
 exports_files(["fake_bazel.sh"])
 


### PR DESCRIPTION
`rules_python` depends on `//tools:BUILD.bazel` in the pre-commit hooks
and it seems that it is impossible to use bazel 8 yet.
