### PR TITLE
fix: look for MODULE.bazel in child repos to remove need for stub WORKSPACE

### DIFF
--- a/bazel_integration_test/private/bazel_integration_test.bzl
+++ b/bazel_integration_test/private/bazel_integration_test.bzl
@@ -18,10 +18,12 @@ _DEFAULT_ENV_INHERIT = ["SUDO_ASKPASS", "HOME", "CC"]
 def _select_workspace_file_impl(ctx):
     workspace_file = paths.join(ctx.attr.workspace_path, "WORKSPACE")
     workspace_bazel = paths.join(ctx.attr.workspace_path, "WORKSPACE.bazel")
+    workspace_module = paths.join(ctx.attr.workspace_path, "MODULE.bazel")
+    workspace_repo = paths.join(ctx.attr.workspace_path, "REPO.bazel")
     for file in ctx.attr.srcs.files.to_list():
-        if file.path.endswith(workspace_file) or file.path.endswith(workspace_bazel):
+        if file.path.endswith(workspace_file) or file.path.endswith(workspace_bazel) or file.path.endswith(workspace_module) or file.path.endswith(workspace_repo):
             return [DefaultInfo(files = depset([file]))]
-    fail("Can't find WORKSPACE or WORKSPACE.bazel in %s" % ctx.attr.workspace_path)
+    fail("Can't find WORKSPACE, WORKSPACE.bazel, MODULE.bazel, nor REPO.bazel in %s" % ctx.attr.workspace_path)
 
 select_workspace_file = rule(
     implementation = _select_workspace_file_impl,


### PR DESCRIPTION
## TL;DR
This minimal change in this PR allows me to use example/child workspaces for integration test without creating empty WORKSPACE files.

## The Challenge

Following the `README.md` to implement `rules_bazel_integration_test`, I found that the _child_workspaces_ needed to have stubbed/empty `WORKSPACE` files in them; creating empty files caused the error to disappear:

```
$TEST_TMPDIR defined: output root default is '/tmp/bazel' and max_idle_secs default is '15'.
Computing main repo mapping: 
Loading: 
Loading: 0 packages loaded
Analyzing: 104 targets (12 packages loaded, 0 targets configured)
Analyzing: 104 targets (12 packages loaded, 0 targets configured)

ERROR: /home/runner/work/rules_synology/rules_synology/examples/BUILD.bazel:29:24: in select_workspace_file rule //examples:example-docker-project_bazel_workspace_file: 
Traceback (most recent call last):
	File "/tmp/bazel/_bazel_runner/7eab14037c39b64dde22b5055c5cbc0f/external/rules_bazel_integration_test~/bazel_integration_test/private/bazel_integration_test.bzl", line 24, column 9, in _select_workspace_file_impl
		fail("Can't find WORKSPACE or WORKSPACE.bazel in %s" % ctx.attr.workspace_path)
Error in fail: Can't find WORKSPACE or WORKSPACE.bazel in example-docker-project
ERROR: /home/runner/work/rules_synology/rules_synology/examples/BUILD.bazel:29:24: Analysis of target '//examples:example-docker-project_bazel_workspace_file' failed
ERROR: Analysis of target '//examples:example-docker-project_bazel_workspace_file' failed; build aborted
INFO: Elapsed time: 1.185s, Critical Path: 0.01s
INFO: 13 processes: 13 internal.
ERROR: Build did NOT complete successfully
FAILED: 
Error: Process completed with exit code 1.
```

This seems to be that the lines modified are not looking for `MODULE.bazel` files as a signal that a valid child workspace exists:

```
    workspace_file = paths.join(ctx.attr.workspace_path, "WORKSPACE")
    workspace_bazel = paths.join(ctx.attr.workspace_path, "WORKSPACE.bazel")
    # no `MODULE.bazel` :(
    
    if file.path.endswith(workspace_file) or file.path.endswith(workspace_bazel):
        return [DefaultInfo(files = depset([file]))]
    fail("Can't find WORKSPACE or WORKSPACE.bazel in %s" % ctx.attr.workspace_path)
```

## Suggested Fix
This minimal change in this PR allows me to re-remove the empty `WORKSPACE` files and have proper functionality back with a `bzlmod`-formatted ruleset, with my _child_workspaces_ -- my examples -- detected by presence of `MODULE.bazel` as I would expect.  The user can choose existing `WORKSPACE`, `WORKSPACE.bazel`, `MODULE.bazel`, or `REPO.bazel` as can be seen in the PR.

**NOTE 1**: I'm unsure whether `REPO.bazel` is appropriate here.

**NOTE 2**: if you test this, you may need to use an absolute path on your `local_path_override()` for the `rules_bazel_integration_test `: I found that a relative path caused the child workspaces to look in the run files location for a `rules_bazel_integration_test ` whereas I had my working copy parallel/peer to my ruleset that I was developing.