### PR TITLE
fix: disable tidy on macos runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
         bazel_repo_cache_dir: ""
         bazel_disk_cache_dir: ""
     - uses: ./.github/actions/tidy_and_test
+      if: ${{ startsWith(matrix.runner, 'ubuntu') }}
+    - if: ${{ startsWith(matrix.runner, 'macos') }}
+      name: Execute tests
+      shell: bash
+      run: "bazelisk test //... \n"
   integration_test_matrix:
     strategy:
       fail-fast: false


### PR DESCRIPTION
Executing `tidy` on the GitHub MacOS runner started generating different results from the Ubuntu runner and local runs, even when run on MacOS. Until we figure it out, we will disable the tidy check on the MacOS runner.

Related to https://github.com/cgrindel/rules_swift_package_manager/issues/1569.
