### PR TITLE
fix: disable `last_green` integration tests

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,8 @@ bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "cgrindel_bazel_starlib", version = "0.27.0")
 bazel_dep(name = "rules_shell", version = "0.3.0")
 
-# not a direct dependency, but required here for bazel starlib's difftest macros to work
+# not a direct dependency, but required here for bazel starlib's difftest
+# macros to work
 bazel_dep(
     name = "buildifier_prebuilt",
     version = "6.1.2",
@@ -25,14 +26,17 @@ bazel_binaries = use_extension(
     dev_dependency = True,
 )
 bazel_binaries.download(version_file = "//:.bazelversion")
-bazel_binaries.download(version = "last_green")
+
+# GH466: Disable last green while we investigate
+# bazel_binaries.download(version = "last_green")
 bazel_binaries.local(path = "tools/fake_bazel.sh")
 use_repo(
     bazel_binaries,
     "bazel_binaries",
     "bazel_binaries_bazelisk",
     "build_bazel_bazel_.bazelversion",
-    "build_bazel_bazel_last_green",
+    # GH466: Disable last green while we investigate
+    # "build_bazel_bazel_last_green",
     "build_bazel_bazel_local",
 )
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -4,7 +4,6 @@ load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load(
     "//bazel_integration_test:defs.bzl",
     "bazel_integration_test",
-    "bazel_integration_tests",
     "default_test_runner",
     "integration_test_utils",
     "script_test",
@@ -72,32 +71,34 @@ bazel_integration_test(
     workspace_path = "simple",
 )
 
-_SIMPLE_TEST_VERSIONS = [
-    version
-    for version in bazel_binaries.versions.other
-    if version != _LOCAL_BAZEL_BINARY_VERSION
-]
+# GH466: Disable last green while we investigate
+# _SIMPLE_TEST_VERSIONS = [
+#     version
+#     for version in bazel_binaries.versions.other
+#     if version != _LOCAL_BAZEL_BINARY_VERSION
+# ]
 
-# If you want to execute an integration test using multiple versions of Bazel,
-# use bazel_integration_tests. It will generate multiple integration test
-# targets with names derived from the base name and the bazel version.
-bazel_integration_tests(
-    # buildifier: disable=duplicated-name
-    name = "simple_test",
-    bazel_binaries = bazel_binaries,
-    bazel_versions = _SIMPLE_TEST_VERSIONS,
-    tags = integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS + [
-        # Avoid file permssion error when using disk and repository cache after
-        # 7.0.0rc2 upgrade.
-        # https://github.com/bazelbuild/bazel/issues/19908
-        "no-sandbox",
-    ],
-    test_runner = ":simple_test_runner",
-    workspace_files = integration_test_utils.glob_workspace_files("simple") + [
-        "//:shared_bazelrc_files",
-    ],
-    workspace_path = "simple",
-)
+# GH466: Disable last green while we investigate
+# # If you want to execute an integration test using multiple versions of Bazel,
+# # use bazel_integration_tests. It will generate multiple integration test
+# # targets with names derived from the base name and the bazel version.
+# bazel_integration_tests(
+#     # buildifier: disable=duplicated-name
+#     name = "simple_test",
+#     bazel_binaries = bazel_binaries,
+#     bazel_versions = _SIMPLE_TEST_VERSIONS,
+#     tags = integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS + [
+#         # Avoid file permssion error when using disk and repository cache after
+#         # 7.0.0rc2 upgrade.
+#         # https://github.com/bazelbuild/bazel/issues/19908
+#         "no-sandbox",
+#     ],
+#     test_runner = ":simple_test_runner",
+#     workspace_files = integration_test_utils.glob_workspace_files("simple") + [
+#         "//:shared_bazelrc_files",
+#     ],
+#     workspace_path = "simple",
+# )
 
 # MARK: - Custom Test Runner Tests
 
@@ -238,9 +239,11 @@ test_suite(
         ":sample_script_test",
         ":simple_test",
         ":use_create_scratch_dir_test",
-    ] + integration_test_utils.bazel_integration_test_names(
-        "simple_test",
-        _SIMPLE_TEST_VERSIONS,
-    ),
+    ],
+    # GH466: Disable last green while we investigate
+    # ] + integration_test_utils.bazel_integration_test_names(
+    #     "simple_test",
+    #     _SIMPLE_TEST_VERSIONS,
+    # ),
     visibility = ["//:__subpackages__"],
 )


### PR DESCRIPTION
Disable the tests until we have worked out a fix.

Related to #466.