### PR TITLE
fix: update_deleted_packages is now deterministic

### DIFF
--- a/tools/find_child_workspace_packages.sh
+++ b/tools/find_child_workspace_packages.sh
@@ -114,4 +114,4 @@ while IFS=$'\n' read -r line; do sorted_abs_path_pkgs+=("$line"); done < <(
 # Strip the workspace_root prefix from the paths
 pkgs=( "${sorted_abs_path_pkgs[@]#"${workspace_root}/"}")
 
-print_by_line "${pkgs[@]}"
+print_by_line "${pkgs[@]}" | sort


### PR DESCRIPTION
It seems that this was causing issues for some of the rules_pythons
hooks. Hopefully the sort allows us to be more deterministic no matter
how the files are ordered.
