### PR TITLE
fix: do not register a python toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,8 +16,6 @@ bazel_dep(
     version = "6.1.2",
 )
 
-register_toolchains("@bazel_tools//tools/python:autodetecting_toolchain")
-
 # Must keep the Bazel version listed in WORKSPACE in sync with those loaded
 # below.
 bazel_binaries = use_extension(


### PR DESCRIPTION
Do not register a python toolchain: this is unnecessary since rules_python registers a default toolchain already. Moreover, this toolchain registration could negatively affect a user of `rules_bazel_integration_test` by registering a toolchain the root module may not want to use (and that might be selected depending on that module's dependency ordering).

Fixes #520